### PR TITLE
Improvement of Robyn code

### DIFF
--- a/source/fb_robyn.func.R
+++ b/source/fb_robyn.func.R
@@ -1020,8 +1020,8 @@ f.mmm <- function(...
       nrmse.collect <- c()
       decomp.rssd.collect <- c()
       best_mape <- Inf
-      closeAllConnections()
-      registerDoParallel(set_cores)  #registerDoParallel(cores=set_cores)
+      registerDoFuture()
+      plan(multicore)
       getDoParWorkers()
       doparCollect <- foreach (
         i = 1:iterPar
@@ -1038,7 +1038,7 @@ f.mmm <- function(...
                         ,'data.table'
         )
         #, .options.snow = opts
-      )  %dopar%  {
+      )  %dorng%  {
         
         t1 <- Sys.time()
         


### PR DESCRIPTION


# Contributing to FB NextGen MMM R script

## Fixes 
- Resolve the problem of R session crashing  after having launched two models in a row on WIndows.
- Drastically reduces model processing time on both operating systems.
- Could potentially fix the problem encountered on Databricks notebooks : #108 

##  Type of change

- Replace doParallel by registerdoFuture and dopar by dorng
- Remove CloseAllConnections()

# How Has This Been Tested?

PC Test Environement 1 : Desktop computer 16 cores / Windows system

+ RegisterDoParallel() :
![doParallel_16cores](https://user-images.githubusercontent.com/86845757/127785334-33c9046a-0b5f-4744-87df-e888900f8204.png)

+ RegisterDoFuture() :
	
![doFuture_16 cores](https://user-images.githubusercontent.com/86845757/127785339-943f043d-e36a-4a7e-8247-3274e0cf29bc.png)

---------------------------------------------------------------------------------------------------------------------------------------------

PC Test Environement 2 : Laptop 8 cores / Windows system	

+ RegisterDoParallel() :
<img width="628" alt="DoregisterParallel_8cores" src="https://user-images.githubusercontent.com/86845757/127785352-2b533a73-a487-4172-aee7-d0961c36dbcb.PNG">

+ RegisterDoFuture(): 
<img width="628" alt="DoFuture_8cores" src="https://user-images.githubusercontent.com/86845757/127785357-4fb492b7-62e4-4dc1-9204-26e43dff4250.PNG">
	
---------------------------------------------------------------------------------------------------------------------------------------------

PC Test Environement 3 : Laptop 4 cores / MAC OS system

+ RegisterDoParallel() :
	
<img width="628" alt="doParallel_MAC OS_ 4 cores" src="https://user-images.githubusercontent.com/86845757/127785360-6a2761e9-655b-44be-ab1b-0bfaf07c76d3.png">

+ RegisterDoFuture() :
<img width="628" alt="doFuture_MAC OS_ 4 cores" src="https://user-images.githubusercontent.com/86845757/127785366-4993b47b-860b-4605-afe3-69122f5a8d3c.png">

## SUMMARY 

<img width="354" alt="Time per trial" src="https://user-images.githubusercontent.com/86845757/127785503-1501ca50-8840-44ac-aa66-9dfbff5fd9bd.PNG">
                          
<img width="354" alt="Total time" src="https://user-images.githubusercontent.com/86845757/127785507-8b0bef1a-ecf4-4281-83ea-585ec804ed88.PNG">
