### PR TITLE
Improvement of Robyn fb_robyn.exec

### DIFF
--- a/source/fb_robyn.exec.R
+++ b/source/fb_robyn.exec.R
@@ -10,7 +10,7 @@
 
 ################################################################
 #### set locale for non English R
-# Sys.setlocale("LC_TIME", "English")
+# Sys.setlocale("LC_TIME", "C")
 
 ################################################################
 #### load libraries
@@ -22,7 +22,6 @@ rm(list=ls()); gc()
 library(data.table) 
 library(stringr) 
 library(lubridate) 
-library(doParallel) 
 library(foreach) 
 library(glmnet) 
 library(car) 
@@ -40,6 +39,8 @@ library(minpack.lm)
 library(rPref)
 library(reticulate)
 library(rstudioapi)
+library(doFuture)
+library(doRNG)
 
 ## please see https://rstudio.github.io/reticulate/index.html for info on installing reticulate
 # conda_create("r-reticulate") # must run this line once


### PR DESCRIPTION

# Contributing to FB NextGen MMM R script

# Type of change

- Sys.setlocale("LC_TIME", "English") does not work on MAC OS.  Sys.setlocale("LC_TIME", "C") is more universal.
- Replace doParallel by doFuture and doRNG 
- doRNG :  enables to easily convert standard %dopar% loops into fully reproducible loops, independently of the number of workers, the task scheduling strategy, or the chosen parallel environment and associated foreach backend).



