### PR TITLE
Remove docs from build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,3 @@
 ^Robyn\.Rproj$
 ^\.Rproj\.user$
+^docs$


### PR DESCRIPTION
No need to import `docs` directory on package builds. We also have to fix dependencies on `DESCRIPTION` file (something like [this](https://github.com/laresbernardo/Robyn/blob/master/DESCRIPTION))