### PR TITLE
Fix error message when no organic vars were provided

### DIFF
--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -565,7 +565,7 @@ robyn_engineering <- function(InputCollect, ...) {
   ################################################################
   #### Obtain prophet trend, seasonality and change-points
 
-  if (!is.null(InputCollect$prophet_vars)) {
+  if (!is.null(InputCollect$prophet_vars) && length(InputCollect$prophet_vars) > 0) {
     dt_transform <- prophet_decomp(
       dt_transform,
       dt_holidays = InputCollect$dt_holidays,
@@ -636,7 +636,7 @@ prophet_decomp <- function(dt_transform, dt_holidays,
     ...
   )
 
-  if (!is.null(factor_vars)) {
+  if (!is.null(factor_vars) && length(factor_vars) > 0) {
     dt_ohe <- as.data.table(model.matrix(y ~ ., dt_regressors[, c("y", factor_vars), with = FALSE]))[, -1]
     ohe_names <- names(dt_ohe)
     for (addreg in ohe_names) modelRecurrance <- add_regressor(modelRecurrance, addreg)

--- a/R/R/model.R
+++ b/R/R/model.R
@@ -317,7 +317,9 @@ robyn_run <- function(InputCollect,
 
     ## plot prophet
 
-    if (!is.null(InputCollect$prophet_vars)) {
+    if (!is.null(InputCollect$prophet_vars) && length(InputCollect$prophet_vars) > 0
+      || !is.null(InputCollect$factor_vars) && length(InputCollect$factor_vars) > 0)
+    {
       # pProphet <- prophet_plot_components(InputCollect$modelRecurrance, InputCollect$forecastRecurrance, render_plot = TRUE)
 
       dt_plotProphet <- InputCollect$dt_mod[, c("ds", "dep_var", InputCollect$prophet_vars, InputCollect$factor_vars), with = FALSE]
@@ -756,7 +758,7 @@ robyn_run <- function(InputCollect,
 
       ## plot fitted vs actual
 
-      if (!is.null(InputCollect$prophet_vars)) {
+      if (!is.null(InputCollect$prophet_vars) && length(InputCollect$prophet_vars) > 0) {
         dt_transformDecomp <- cbind(dt_modRollWind[, c("ds", "dep_var", InputCollect$prophet_vars, InputCollect$context_vars), with = FALSE], dt_transformSaturation[, InputCollect$all_media, with = FALSE])
       } else {
         dt_transformDecomp <- cbind(dt_modRollWind[, c("ds", "dep_var", InputCollect$context_vars), with = FALSE], dt_transformSaturation[, InputCollect$all_media, with = FALSE])

--- a/R/R/model.R
+++ b/R/R/model.R
@@ -826,7 +826,7 @@ robyn_run <- function(InputCollect,
       }
 
       ## prepare output
-      if (!is.null(InputCollect$organic_vars)) {
+      if (!is.null(InputCollect$organic_vars) && length(InputCollect$organic_vars) > 0) {
         dt_transformSpend[, (InputCollect$organic_vars) := NA]
         dt_transformSpendMod[, (InputCollect$organic_vars) := NA]
         dt_transformSaturationSpendReverse[, (InputCollect$organic_vars) := NA]


### PR DESCRIPTION
Our team found following error message if we run RobynMMM without organic vars (empty vector in parameters)

Error message:
```
>>> Plotting 17 Pareto optimum models...
|====
Error in `[.data.table`(dt_transformSpend, , `:=`((InputCollect$organic_vars),  (run_robyn_mmm.R#209): LHS of := isn't column names ('character') or positions ('integer' or 'numeric')
```

Fix is quite simple - please review it.

The change has been tested on real production data.
