### PR TITLE
Added version_prompt parameter to robyn_refresh()

### DIFF
--- a/R/R/refresh.R
+++ b/R/R/refresh.R
@@ -189,6 +189,7 @@ robyn_refresh <- function(robyn_object,
                           refresh_iters = 1000,
                           refresh_trials = 3,
                           plot_pareto = TRUE,
+                          version_prompt = FALSE,
                           ...) {
   refreshControl <- TRUE
   while (refreshControl) {
@@ -362,12 +363,21 @@ robyn_refresh <- function(robyn_object,
     # norm_rssd <- .min_max_norm(OutputCollectRF$resultHypParam$decomp.rssd)
     OutputCollectRF$resultHypParam[, error_dis := sqrt(.min_max_norm(nrmse)^2 +
                                                          .min_max_norm(decomp.rssd)^2)] # min error distance selection
-    selectID <- OutputCollectRF$resultHypParam[which.min(error_dis), solID]
-    OutputCollectRF$selectID <- selectID
-    message(
-      "Selected model ID: ", selectID, " for refresh model nr.",
-      refreshCounter, " based on the smallest combined error of normalised NRMSE & DECOMP.RSSD\n"
-    )
+    if (version_prompt) {
+      selectID <- readline('Input model version to use for the refresh: ')
+      OutputCollectRF$selectID <- selectID
+      message(
+        "Selected model ID: ", selectID, " for refresh model nr.",
+        refreshCounter, " based on your input\n"
+      )
+    } else {
+      selectID <- OutputCollectRF$resultHypParam[which.min(error_dis), solID]
+      OutputCollectRF$selectID <- selectID
+      message(
+        "Selected model ID: ", selectID, " for refresh model nr.",
+        refreshCounter, " based on the smallest combined error of normalised NRMSE & DECOMP.RSSD\n"
+      )
+    }
 
     OutputCollectRF$resultHypParam[, bestModRF := solID == selectID]
     OutputCollectRF$xDecompAgg[, bestModRF := solID == selectID]

--- a/R/R/refresh.R
+++ b/R/R/refresh.R
@@ -145,6 +145,10 @@ plot.robyn_save <- function(x, ...) plot(x$plot[[1]], ...)
 #' still needs to be investigated.
 #' @param refresh_trials Integer. Trials per refresh. Defaults to 5 trials.
 #' More reliable recommendation still needs to be investigated.
+#' @param version_prompt Logical. If FALSE, the model refresh version will be
+#' selected based on the smallest combined error of normalised NRMSE & DECOMP.RSSD.
+#' If TRUE, a prompt will be presented to the user to select one of the refreshed
+#' models (one-pagers and pareto csv files will already be generated).
 #' @param ... Additional parameters to overwrite original custom parameters
 #' passed into initial model.
 #' @return List. The Robyn object, class \code{robyn_refresh}.

--- a/R/man/robyn_refresh.Rd
+++ b/R/man/robyn_refresh.Rd
@@ -15,6 +15,7 @@ robyn_refresh(
   refresh_iters = 1000,
   refresh_trials = 3,
   plot_pareto = TRUE,
+  version_prompt = FALSE,
   ...
 )
 
@@ -54,6 +55,11 @@ More reliable recommendation still needs to be investigated.}
 
 \item{plot_pareto}{Boolean. Set to \code{FALSE} to deactivate plotting
 and saving model one-pagers. Used when testing models.}
+
+\item{version_prompt}{Logical. If FALSE, the model refresh version will be
+selected based on the smallest combined error of normalised NRMSE & DECOMP.RSSD.
+If TRUE, a prompt will be presented to the user to select one of the refreshed
+models (one-pagers and pareto csv files will already be generated).}
 
 \item{...}{Additional parameters to overwrite original custom parameters
 passed into initial model.}


### PR DESCRIPTION
# Project Robyn

Currently the refresh() function selects the refresh version on its own. Here I added an additional bool param version_prompt that allows to pause the code and ask the user to input a specific refresh model name.

# Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Locally on personal machine using custom dataset

Checklist:

- Fork the repo and create your branch from master.
- If you've added code that should be tested, add tests.
- If you've changed APIs, update the documentation.
- Ensure the test suite passes.
- Make sure your code lints.
