### PR TITLE
Add NA positions to error message in check_nas()

### DIFF
--- a/R/R/checks.R
+++ b/R/R/checks.R
@@ -222,7 +222,7 @@ check_paidmedia <- function(dt_input, paid_media_vars, paid_media_signs, paid_me
     })
     stop(
       paste(names(check_media_val)[check_media_val], collapse = ", "),
-      "contains negative values. Media must be >=0"
+      " contains negative values. Media must be >=0"
     )
   }
   return(invisible(list(

--- a/R/R/checks.R
+++ b/R/R/checks.R
@@ -10,9 +10,14 @@ opts_pnd <- c("positive", "negative", "default")
 check_nas <- function(df) {
   if (sum(is.na(df)) > 0) {
     name <- deparse(substitute(df))
-    stop(paste(
-      "Dataset", name, "has missing values.",
-      "These values must be removed or fixed for the model to properly run"
+    naPositions <- which(is.na(df), arr.ind=TRUE)
+    formattedPositions <- paste(apply(t(naPositions), 2, function(pos) {
+      paste0(" - row=", pos[1], ", col=", pos[2])
+    }), collapse="\n")
+    stop(paste0(
+      "Dataset ", name, " has missing values. ",
+      "These values must be removed or fixed for the model to properly run:\n",
+      formattedPositions
     ))
   }
 }


### PR DESCRIPTION
It is quite hard to find where NA appeared in source data when you're dealing with huge XLSX file with formulas.
Adding NA positions to error message should greatly help in these cases.

Example output after my fix:
```
Error in check_nas(dt_input) (run_robyn_mmm.R#148): Dataset dt_input has
missing values. These values must be removed or fixed for the model to
properly run:
 - row=613, col=13
 - row=752, col=13
 - row=753, col=13
 - row=754, col=13
 - row=613, col=14
 - row=752, col=14
 - row=753, col=14
 - row=754, col=14
```

# Type of change
- Improvement (non breaking change)

# How Has This Been Tested?
Tested on our local Robyn-based project.
