### PR TITLE
refactor: modify inflexion computation for precision and simplicity

### DIFF
--- a/R/R/transformation.R
+++ b/R/R/transformation.R
@@ -169,11 +169,11 @@ adstock_weibull <- function(x, shape, scale, windlen = length(x), type = "CDF") 
 #' @return Numeric values. Transformed values.
 #' @export
 saturation_hill <- function(x, alpha, gamma, x_marginal = NULL) {
-  gammaTrans <- round(quantile(seq(range(x)[1], range(x)[2], length.out = 100), gamma), 4)
+  inflexion <- c(range(x) %*% c(1 - gamma, gamma)) # linear interpolation by dot product
   if (is.null(x_marginal)) {
-    x_scurve <- x**alpha / (x**alpha + gammaTrans**alpha) # plot(x_scurve) summary(x_scurve)
+    x_scurve <- x**alpha / (x**alpha + inflexion**alpha) # plot(x_scurve) summary(x_scurve)
   } else {
-    x_scurve <- x_marginal**alpha / (x_marginal**alpha + gammaTrans**alpha)
+    x_scurve <- x_marginal**alpha / (x_marginal**alpha + inflexion**alpha)
   }
   return(x_scurve)
 }


### PR DESCRIPTION
# Project Robyn

I tried to recreate the computation of the Hill saturation function, and found that Robyn's code for it seemed unnecessarily convoluted and wasteful.

Why is `range(x)` computed twice? (Maybe the R compiler is smart enough to just do it once anyway?)
Why create a linear sequence (and why with 100 steps in particular?) when it is immediately reduced to a scalar with `quantile`?
Why round the result at all, and why round to four decimals in particular?

I think all these things are unnecessary, and rewrote the computation to use a simple linear interpolation instead. I also renamed the variable to reflect it's content.

# Type of change

- Code cleanup

# How Has This Been Tested?

By logical reasoning and by manual comparison of the original and proposed computations on the same test data.