### PR TITLE
pareto_front.png - Show blue dots on top of grey dots

### DIFF
--- a/R/R/plots.R
+++ b/R/R/plots.R
@@ -93,6 +93,8 @@ robyn_plots <- function(InputCollect, OutputCollect, export = TRUE) {
       resultHypParam <- copy(temp_all$resultHypParam)
       if (!is.null(InputCollect$calibration_input)) {
         resultHypParam[, iterations := ifelse(is.na(robynPareto), NA, iterations)]
+        # show blue dots on top of grey dots
+        resultHypParam <- resultHypParam[order(!is.na(robynPareto))]
       }
 
       calibrated <- !is.null(InputCollect$calibration_input)


### PR DESCRIPTION
# Project Robyn

pareto_front.png - sometimes blue dots are almost not visible behind of grey dots.
It happens when running Robyn MMM with calibration input with many iterations (6000) and trials (10).

I've sorted data frame before rendering to render blue dots after grey dots.
See screenshot: 

![image](https://user-images.githubusercontent.com/5568564/176011659-7fa55e46-9e78-437f-9b1b-3a52cf3922b4.png)


# Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This change has been tested on internal project.