### PR TITLE
Fix channel names matching in calibrate_mmm()

### DIFF
--- a/R/R/model.R
+++ b/R/R/model.R
@@ -1227,7 +1227,7 @@ calibrate_mmm <- function(calibration_input, decompCollect, dayInterval) {
 
   # Loop per lift channel
   for (m in seq_along(getLiftMedia)) {
-    liftWhich <- str_which(calibration_input$channel, getLiftMedia[m])
+    liftWhich <- which(calibration_input$channel == getLiftMedia[m])
     liftCollect2 <- list()
 
     # Loop per lift test per channel


### PR DESCRIPTION
# Project Robyn

During debug of calibration MAPE calculation function I've found a small bug in calibration_input channel names matching.
It could cause wrong MAPE calculation in rare cases. Pls see the example and fix below:

```
getLiftMedia[m]<- c('google')
calibration_input$channel <- c('facebook', 'google', 'google_organic')

# original version
liftWhich <- str_which(calibration_input$channel, getLiftMedia[m])
# returns: 2 3 - incorrect, google_organic != google

# fixed version
liftWhich <- which(calibration_input$channel == getLiftMedia[m])
# returns: 2
```

# Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on our internal Robyn-based project.
