### PR TITLE
update robyn_response() to receive numeric vector

### DIFF
--- a/R/R/checks.R
+++ b/R/R/checks.R
@@ -723,19 +723,14 @@ check_allocator <- function(OutputCollect, select_model, paid_media_spends, scen
 
 check_metric_value <- function(metric_value, media_metric) {
   if (!is.null(metric_value)) {
-    if (length(metric_value) != 1) {
-      stop(sprintf(
-        "Input 'metric_value' for %s (%s) must be a valid numerical value", media_metric, metric_value
-      ))
-    }
     if (!is.numeric(metric_value)) {
       stop(sprintf(
-        "Input 'metric_value' for %s (%s) must be a numerical value", media_metric, metric_value
+        "Input 'metric_value' for %s (%s) must be a numerical value\n", media_metric, toString(metric_value)
       ))
     }
-    if (metric_value <= 0) {
+    if (sum(metric_value <= 0) > 0 ) {
       stop(sprintf(
-        "Input 'metric_value' for %s (%s) must be a positive value", media_metric, metric_value
+        "Input 'metric_value' for %s (%s) must be a positive value\n", media_metric, metric_value[metric_value <= 0]
       ))
     }
   }

--- a/R/man/robyn_response.Rd
+++ b/R/man/robyn_response.Rd
@@ -33,7 +33,7 @@ is provided, \code{select_model} defaults to the already selected \code{SolID}. 
 \code{InputCollect} and \code{OutputCollect}, and must be one of
 \code{OutputCollect$allSolutions}.}
 
-\item{metric_value}{Numeric. Desired metric value to return a response for.}
+\item{metric_value}{Numeric. Vector of desired metric value to return a response for.}
 
 \item{dt_hyppar}{A data.frame. When \code{robyn_object} is not provided, use
 \code{dt_hyppar = OutputCollect$resultHypParam}. It must be provided along


### PR DESCRIPTION
# Project Robyn
update robyn_response() to receive numeric vector.
current robyn_response allow to receive numeric value. If we want to get multiple result we needed to run multiple times or loop it. It takes so much time to try it. By allowing numeric vector it will reduce time of getting outputs.

Fixes # (issue)

# Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Unit test of robyn_response().
Tested 
- to allow numeric value and vectors.
- send error if it is not numeric vector.
- send error if it has negative value.

Checklist:

- Fork the repo and create your branch from master.
- If you've added code that should be tested, add tests.
- If you've changed APIs, update the documentation.
- Ensure the test suite passes.
- Make sure your code lints.
