### PR TITLE
check if there is nan in metric_value for vectors

### DIFF
--- a/R/R/response.R
+++ b/R/R/response.R
@@ -185,7 +185,7 @@ robyn_response <- function(InputCollect = NULL,
     ))
   }
 
-  if (is.nan(metric_value)) metric_value <- NULL
+  if (any(is.nan(metric_value))) metric_value <- NULL
   check_metric_value(metric_value, media_metric)
 
   ## Transform exposure to spend when necessary


### PR DESCRIPTION
## Project Robyn
With Robyn 3.7.1 

Fixes # (issue)
robyn_response didn't receive vector due to is.nan(metric_value)

## Type of change
- fix: Bug fix (non-breaking change which fixes an issue)
update to  receive vector

## How Has This Been Tested?
Ensure all tests pass, run `devtools::check()`. Should have no notes, no warning, no errors.
test by passing numeric vector and numeric value