### PR TITLE
solution for preventing vectory memory exhaused

### DIFF
--- a/demo/demo.R
+++ b/demo/demo.R
@@ -343,6 +343,10 @@ print(OutputCollect)
 # pareto_media_transform_matrix.csv, all media transformation vectors
 # pareto_alldecomp_matrix.csv, all decomposition vectors of independent variables
 
+## MacOS Only: If vector memory exhaused, increase physical and virtual memory allocation
+# install.packages("usethis")
+# library(usethis)
+# usethis::edit_r_environ() # Once a new R studio tab opens, add this to the first line: R_MAX_VSIZE=100Gb
 
 ################################################################
 #### Step 4: Select and save the any model


### PR DESCRIPTION
## Project Robyn

After upgrading to  Robyn v 3.8.1 I was experiencing vector memory exhausted error in which I could not export files from OutputCollect on my MacOS using 8k iterations and 4 trials.

Fixes # (issue)
In order to solve this, I increased the physical and virtual memory allocated through R_MAX_VSIZE=100Gb 

## Type of change
I added 4 lines of commented out code to increase memory

## How Has This Been Tested?
I am successfully running models that were previously causing the error
