### PR TITLE
Feat: robyn_run outputs parameter deprecation #554

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -41,7 +41,7 @@ Config/reticulate:
   )
 URL: https://github.com/facebookexperimental/Robyn, https://facebookexperimental.github.io/Robyn/
 BugReports: https://github.com/facebookexperimental/Robyn/issues
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/R/R/model.R
+++ b/R/R/model.R
@@ -34,7 +34,6 @@
 #' and refit the model. Consider changing intercept_sign to "unconstrained" when
 #' there are \code{context_vars} with large positive values.
 #' @param seed Integer. For reproducible results when running nevergrad.
-#' @param outputs Boolean. Process results with \code{robyn_outputs()}?
 #' @param lambda_control Deprecated in v3.6.0.
 #' @param ... Additional parameters passed to \code{robyn_outputs()}.
 #' @return List. Class: \code{robyn_models}. Contains the results of all trials
@@ -46,8 +45,7 @@
 #'   InputCollect = InputCollect,
 #'   cores = 2,
 #'   iterations = 200,
-#'   trials = 1,
-#'   outputs = FALSE
+#'   trials = 1
 #' )
 #' }
 #' @return List. Contains all trained models. Class: \code{robyn_models}.
@@ -58,7 +56,6 @@ robyn_run <- function(InputCollect = NULL,
                       add_penalty_factor = FALSE,
                       refresh = FALSE,
                       seed = 123L,
-                      outputs = FALSE,
                       quiet = FALSE,
                       cores = NULL,
                       trials = 5,
@@ -153,16 +150,8 @@ robyn_run <- function(InputCollect = NULL,
     OutputModels$hyper_updated <- hyper_collect$hyper_list_all
   }
 
-  # Not direct output & not all fixed hyppar
-  if (!outputs & is.null(dt_hyper_fixed)) {
+  # Deprecated outputs parameter so the user will run robyn_outputs()
     output <- OutputModels
-  } else if (!hyper_collect$all_fixed) {
-    # Direct output & not all fixed hyppar, including refresh mode
-    output <- robyn_outputs(InputCollect, OutputModels, refresh = refresh, ...)
-  } else {
-    # Direct output & all fixed hyppar, thus no cluster
-    output <- robyn_outputs(InputCollect, OutputModels, clusters = FALSE, ...)
-  }
 
   # Check convergence when more than 1 iteration
   if (!hyper_collect$all_fixed) {

--- a/R/R/plots.R
+++ b/R/R/plots.R
@@ -222,6 +222,7 @@ robyn_plots <- function(InputCollect, OutputCollect, export = TRUE) {
 #' Generate and Export Robyn One-Pager Plots
 #'
 #' @inheritParams robyn_outputs
+#' @inheritParams robyn_allocator
 #' @inheritParams robyn_csv
 #' @return Invisible list with \code{patchwork} plot(s).
 #' @export

--- a/R/man/robyn_onepagers.Rd
+++ b/R/man/robyn_onepagers.Rd
@@ -13,8 +13,8 @@ robyn_onepagers(
 )
 }
 \arguments{
-\item{InputCollect}{\code{robyn_inputs()} and \code{robyn_run()}
-outcomes.}
+\item{InputCollect}{List. Contains all input parameters for the model.
+Required when \code{robyn_object} is not provided.}
 
 \item{OutputCollect}{\code{robyn_run(..., export = FALSE)} output.}
 

--- a/R/man/robyn_run.Rd
+++ b/R/man/robyn_run.Rd
@@ -12,7 +12,6 @@ robyn_run(
   add_penalty_factor = FALSE,
   refresh = FALSE,
   seed = 123L,
-  outputs = FALSE,
   quiet = FALSE,
   cores = NULL,
   trials = 5,
@@ -43,8 +42,6 @@ more iterations to converge.}
 \item{refresh}{Boolean. Set to \code{TRUE} when used in \code{robyn_refresh()}.}
 
 \item{seed}{Integer. For reproducible results when running nevergrad.}
-
-\item{outputs}{Boolean. Process results with \code{robyn_outputs()}?}
 
 \item{quiet}{Boolean. Keep messages off?}
 
@@ -90,8 +87,7 @@ OutputCollect <- robyn_run(
   InputCollect = InputCollect,
   cores = 2,
   iterations = 200,
-  trials = 1,
-  outputs = FALSE
+  trials = 1
 )
 }
 }

--- a/demo/demo.R
+++ b/demo/demo.R
@@ -313,8 +313,7 @@ OutputModels <- robyn_run(
   cores = NULL, # NULL defaults to max available - 1
   iterations = 2000, # 2000 recommended for the dummy dataset with no calibration
   trials = 5, # 5 recommended for the dummy dataset
-  add_penalty_factor = FALSE, # Experimental feature. Use with caution.
-  outputs = FALSE # outputs = FALSE disables direct model output - robyn_outputs()
+  add_penalty_factor = FALSE # Experimental feature. Use with caution.
 )
 print(OutputModels)
 

--- a/website/docs/releases.mdx
+++ b/website/docs/releases.mdx
@@ -5,6 +5,24 @@ title: Releases
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
+## 3.8.2 (2022-11-23)
+### Memory friendly outputs, progress bars for Pareto-front models, bugs and docs
+- **Feat**: new status bars for Pareto-Front models per trial to provide information on calculation status
+- **Feat**: included carryover results into pareto_aggregated.csv output and `OutputCollect$xDecompAgg$carryover_pct`
+- **Feat**: new error message shows which hyperparameters inputs are missing #543
+- **Fix**:  substantially reduced the size of `robyn_run()` and `robyn_outputs()` results (around -80% compared with 3.8.1 version's size) by removing redundant and unused data from outputs #534
+- **Fix**: invalid argument type in check_factorvars() and issue recreating calibrated models #520
+- **Fix**: `add_penalty_factor` parameter now works correctly with JSON files and `robyn_refresh()` #543
+- **Fix**: correct hyper-parameters length for custom data #533
+- **Fix**: bug in RobynLearn when checking numerical data #532
+- **Fix**: removed .iData format for legacy demo .RData files
+- **Fix**: passing custom `pareto_fronts` input instead of "auto" now works as expected
+- **Docs**: updated released version on website, meta.com emails, update CRAN link on `robyn_update()`
+
+**Full Changelog**: https://github.com/facebookexperimental/Robyn/compare/v3.8.0...v3.8.2
+
+---
+
 ## 3.8.0 (2022-10-27)
 ### Bootstrapped CI, Immediate vs Carryover, Multi-channel calibration
 


### PR DESCRIPTION
## Project Robyn

Removed outputs = FALSE from robyn_run()

Fixes #554 

## Type of change
- feat: New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested by running outputs = TRUE, outputs = FALSE, and without defining outputs ran successfully and the output was consumed by the following function robyn_outputs()
Updated the documentation, removed the parameter from demo.R script

##Additional Info
The decision to make the deprecation comes from the fact that outputs = TRUE is redundant. The user is still required to run robyn_outputs() where the params are inherited for the allocator and clusters 