### PR TITLE
Docs: updated v3.9.0 to releases

### DIFF
--- a/website/docs/releases.mdx
+++ b/website/docs/releases.mdx
@@ -5,6 +5,21 @@ title: Releases
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
+## 3.9.0 (2022-12-15)
+### Time-series validation feature
+- **Feat**: new time series validation via time-series train/val/test dynamic splits and Adjusted R2 and NRMSE metrics reported for each group feature #545. We are adding an additional `train_size` hyperparameter to pick the size of the training size, which by default will iterate in the range of 0.5-0.8. Given it's a hyperparameter, you can change the range or fix the value manually. Turn on/off this feature using the `ts_validation` new parameter on `robyn_run()`; default is set to `FALSE` for now. This is an important step for the forecasting coming function.
+- **Feat**: new `ts_validation()` function to plot time-series validation and convergence results. Generated and exported by default when `ts_validation = TRUE`, and when `export = TRUE`, creating `ts_validation_plot.png` file.
+- **Fix**: updated Adjusted R2 calculation (`get_rsq()`) for time-series validation using same denominator.
+- **Fix**: results are not sorted by lowest errors now to keep iteration results actual order.
+- **Feat**: added prophet monthly component to enrich decomposition results #525
+- **Fix**: correct solID (not "1_1_1") for fixed hyperparameters recreated models.
+- **Recode**: reduced the size of `xDecompVec` on `OutputCollect` by keeping pareto-front models only.
+- **Docs**: changed standard inputs on [demo.R](https://github.com/facebookexperimental/Robyn/blob/main/demo/demo.R) file for modeling window to include more data (3 years by default).
+
+**Full Changelog**: https://github.com/facebookexperimental/Robyn/compare/v3.8.2...v3.9.0
+
+---
+
 ## 3.8.2 (2022-11-23)
 ### Memory friendly outputs, progress bars for Pareto-front models, bugs and docs
 - **Feat**: new status bars for Pareto-Front models per trial to provide information on calculation status


### PR DESCRIPTION
Docs: updated v3.9.0 to releases
Tested by markdown renderer
