### PR TITLE
fix: separate OutputCollect$OutputModels and OutputModels to produce ts_validation plot export #596

### DIFF
--- a/R/R/outputs.R
+++ b/R/R/outputs.R
@@ -87,16 +87,13 @@ robyn_outputs <- function(InputCollect, OutputModels,
   allSolutions <- pareto_results$pareto_solutions
 
   # Reduce the size of xDecompVec with only pareto-front models and create solID
-  OutputModels[names(OutputModels) %in% paste0("trial", 1:OutputModels$trials)] <- lapply(
-    OutputModels[names(OutputModels) %in% paste0("trial", 1:OutputModels$trials)],
-    function(x) {
-      mutate(x$resultCollect$xDecompVec,
-        solID = paste(.data$trial, .data$iterNG, .data$iterPar, sep = "_")
-      ) %>%
-        filter(.data$solID %in% allSolutions) %>%
-        select(-.data$iterNG, -.data$iterPar)
-    }
-  )
+  for (i in seq(OutputModels$trials)) {
+    OutputModels[names(OutputModels) %in% paste0("trial", i)][[1]]$resultCollect$xDecompVec <-
+      OutputModels[names(OutputModels) %in% paste0("trial", i)][[1]]$resultCollect$xDecompVec %>%
+      mutate(solID = paste(.data$trial, .data$iterNG, .data$iterPar, sep = "_")) %>%
+      filter(.data$solID %in% pareto_results$pareto_solutions) %>%
+      select(-c("iterNG", "iterPar"))
+  }
 
   #####################################
   #### Gather the results into output object

--- a/R/R/plots.R
+++ b/R/R/plots.R
@@ -222,9 +222,8 @@ robyn_plots <- function(InputCollect, OutputCollect, export = TRUE, ...) {
     }
   } # End of !hyper_fixed
 
-  OutputModels$ts_validation_plot <- ts_validation(OutputModels, quiet = TRUE, ...)
   if (isTRUE(OutputCollect$OutputModels$ts_validation)) {
-    ts_validation_plot <- ts_validation(OutputModels, quiet = TRUE, ...)
+    ts_validation_plot <- ts_validation(OutputCollect$OutputModels, quiet = TRUE, ...)
     ggsave(
       paste0(OutputCollect$plot_folder, "ts_validation", ".png"),
       plot = ts_validation_plot, dpi = 300,
@@ -1090,18 +1089,12 @@ refresh_plots_json <- function(OutputCollectRF, json_file, export = TRUE) {
 #' @return Invisible list with \code{ggplot} plots.
 #' @export
 ts_validation <- function(OutputModels, quiet = FALSE, ...) {
-  if ("resultCollect" %in% names(OutputModels$trial1)) {
-    resultHypParam <- bind_rows(
-      lapply(OutputModels[
-        which(names(OutputModels) %in% paste0("trial", seq(OutputModels$trials)))
-      ], function(x) x$resultCollect$resultHypParam)
-    )
-  } else {
-    resultHypParam <- bind_rows(OutputModels[
+  if (!isTRUE(OutputModels$ts_validation)) return(NULL)
+  resultHypParam <- bind_rows(
+    lapply(OutputModels[
       which(names(OutputModels) %in% paste0("trial", seq(OutputModels$trials)))
-    ])
-  }
-  resultHypParam <- resultHypParam%>%
+    ], function(x) x$resultCollect$resultHypParam)
+  ) %>%
     group_by(.data$trial) %>%
     mutate(i = row_number()) %>%
     ungroup()

--- a/R/R/plots.R
+++ b/R/R/plots.R
@@ -223,10 +223,11 @@ robyn_plots <- function(InputCollect, OutputCollect, export = TRUE, ...) {
   } # End of !hyper_fixed
 
   OutputModels$ts_validation_plot <- ts_validation(OutputModels, quiet = TRUE, ...)
-  if (!is.null(OutputModels$ts_validation_plot)) {
+  if (isTRUE(OutputCollect$OutputModels$ts_validation)) {
+    ts_validation_plot <- ts_validation(OutputModels, quiet = TRUE, ...)
     ggsave(
       paste0(OutputCollect$plot_folder, "ts_validation", ".png"),
-      plot = OutputModels$ts_validation_plot, dpi = 300,
+      plot = ts_validation_plot, dpi = 300,
       width = 10, height = 12, limitsize = FALSE
     )
   }
@@ -1089,14 +1090,18 @@ refresh_plots_json <- function(OutputCollectRF, json_file, export = TRUE) {
 #' @return Invisible list with \code{ggplot} plots.
 #' @export
 ts_validation <- function(OutputModels, quiet = FALSE, ...) {
-  if (!isTRUE(OutputModels$ts_validation)) {
-    return(NULL)
-  }
-  resultHypParam <- bind_rows(
-    lapply(OutputModels[
+  if ("resultCollect" %in% names(OutputModels$trial1)) {
+    resultHypParam <- bind_rows(
+      lapply(OutputModels[
+        which(names(OutputModels) %in% paste0("trial", seq(OutputModels$trials)))
+      ], function(x) x$resultCollect$resultHypParam)
+    )
+  } else {
+    resultHypParam <- bind_rows(OutputModels[
       which(names(OutputModels) %in% paste0("trial", seq(OutputModels$trials)))
-    ], function(x) x$resultCollect$resultHypParam)
-  ) %>%
+    ])
+  }
+  resultHypParam <- resultHypParam%>%
     group_by(.data$trial) %>%
     mutate(i = row_number()) %>%
     ungroup()


### PR DESCRIPTION
When enabling ts_validation for OutputModels, robyn_outputs did not output the one-pager plots in the plot folder. This happened because OutputCollect$OutputModels (from robyn_outputs()) and OutputModels (from robyn_run()) are different and were being treated as equal. The following fix in the plots.R file allows both OutputModels to exist.

`if ("resultCollect" %in% names(OutputModels$trial1)) {
    resultHypParam <- bind_rows(
      lapply(OutputModels[
        which(names(OutputModels) %in% paste0("trial", seq(OutputModels$trials)))
      ], function(x) x$resultCollect$resultHypParam)
    )
  } else {
    resultHypParam <- bind_rows(OutputModels[
      which(names(OutputModels) %in% paste0("trial", seq(OutputModels$trials)))
    ])
  }
  resultHypParam <- resultHypParam%>%
    group_by(.data$trial) %>%
    mutate(i = row_number()) %>%
    ungroup()`


Tested using demo.R script and demo debug script provided in #596
