### PR TITLE
Call as.Date on `floor_date` call

### DIFF
--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -956,7 +956,7 @@ set_holidays <- function(dt_transform, dt_holidays, intervalType) {
     weekStartInput <- lubridate::wday(dt_transform$ds[1], week_start = 1)
     if (!weekStartInput %in% c(1, 7)) stop("Week start has to be Monday or Sunday")
     holidays <- dt_holidays %>%
-      mutate(ds = floor_date(as.Date(.data$ds), unit = "week", week_start = weekStartInput)) %>%
+      mutate(ds = floor_date(as.Date(.data$ds, origin = "1970-01-01"), unit = "week", week_start = weekStartInput)) %>%
       select(.data$ds, .data$holiday, .data$country, .data$year) %>%
       group_by(.data$ds, .data$country, .data$year) %>%
       summarise(holiday = paste(.data$holiday, collapse = ", "), n = n())

--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -956,7 +956,7 @@ set_holidays <- function(dt_transform, dt_holidays, intervalType) {
     weekStartInput <- lubridate::wday(dt_transform$ds[1], week_start = 1)
     if (!weekStartInput %in% c(1, 7)) stop("Week start has to be Monday or Sunday")
     holidays <- dt_holidays %>%
-      mutate(ds = floor_date(.data$ds, unit = "week", week_start = weekStartInput)) %>%
+      mutate(ds = floor_date(as.Date(.data$ds), unit = "week", week_start = weekStartInput)) %>%
       select(.data$ds, .data$holiday, .data$country, .data$year) %>%
       group_by(.data$ds, .data$country, .data$year) %>%
       summarise(holiday = paste(.data$holiday, collapse = ", "), n = n())


### PR DESCRIPTION
## Project Robyn

Adjust the code so that it does not assume the column `ds` of the `dt_holidays` df is of type `datetime`, instead convert it using `as.Date`

Fixes #662

## Type of change

- fix: Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Was having issues running the process using `3.9.0`
- Forked the repo
- Updated the code and installed my own fork
- Ran it again and the error is gone
