### PR TITLE
Respect plot_folder value on robyn_refresh

### DIFF
--- a/R/R/refresh.R
+++ b/R/R/refresh.R
@@ -132,7 +132,11 @@ robyn_refresh <- function(json_file = NULL,
       listInit$InputCollect$refreshDepth <- refreshDepth <- length(attr(chainData, "chain"))
       listInit$OutputCollect$hyper_updated <- json$ExportedModel$hyper_updated
       Robyn[["listInit"]] <- listInit
-      objectPath <- json$ExportedModel$plot_folder
+      if (is.null(plot_folder)) {
+        objectPath <- json$ExportedModel$plot_folder
+      } else {
+        objectPath <- plot_folder
+      }
       refreshCounter <- 1 # Dummy for now (legacy)
     }
     if (!is.null(robyn_object)) {


### PR DESCRIPTION
## Project Robyn

The value of `plot_folder` is not being respected when calling `robyn_refresh` which results in the original folder being used by default (as described in #649). This PR adjust the code so that `plot_folder`'s value is respected when present.

Fixes #649

## Type of change
- fix: Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Fork the repo and create your branch from master (latest dev version).
- [x] ~If you've changed documentation, run `devtools::document()`. Should update .Rd files.~
- [x] Ensure all tests pass, run `devtools::check()`. Should have no notes, no warning, no errors.
- [x] Make sure your code lints.
