### PR TITLE
Bug fix for pareto_alldecomp_matrix.csv

### DIFF
--- a/R/R/pareto.R
+++ b/R/R/pareto.R
@@ -351,7 +351,12 @@ robyn_pareto <- function(InputCollect, OutputModels,
       for (i in seq_along(InputCollect$paid_media_vars)) {
         channel <- InputCollect$paid_media_vars[i]
         col_name <- InputCollect$paid_media_spends[i]
-        dt_transformSpendMod[col_name] <- InputCollect$modNLS$yhat[InputCollect$modNLS$yhat$models == 'nls' & InputCollect$modNLS$yhat$channel == channel,"yhat"]
+        if(channel!=col_name){
+          dt_transformSpendMod[col_name] <- InputCollect$modNLS$yhat[InputCollect$modNLS$yhat$models == 'nls' & InputCollect$modNLS$yhat$channel == channel,"yhat"]
+        }
+        else{
+          dt_transformSpendMod[col_name] <- dt_transformPlot[[col_name]]
+        }
       }
       for (organic_var in InputCollect$organic_vars) {
         dt_transformSpendMod[[organic_var]] <- dt_transformPlot[[organic_var]]

--- a/R/R/pareto.R
+++ b/R/R/pareto.R
@@ -346,6 +346,7 @@ robyn_pareto <- function(InputCollect, OutputModels,
       dt_transformPlot <- select(dt_mod, .data$ds, all_of(InputCollect$all_media)) # independent variables
       dt_transformSpend <- cbind(dt_transformPlot[, "ds"], InputCollect$dt_input[, c(InputCollect$paid_media_spends)]) # spends of indep vars
       dt_transformVars <- cbind(dt_transformPlot[, "ds"], InputCollect$dt_input[, c(InputCollect$paid_media_vars)])
+      colnames(dt_transformVars) <- append (c("ds"), InputCollect$paid_media_spends) 
       dt_transformSpendMod <- data.frame(ds = select(InputCollect$dt_mod,.data$ds))
       for (i in seq_along(InputCollect$paid_media_vars)) {
         channel <- InputCollect$paid_media_vars[i]
@@ -353,7 +354,8 @@ robyn_pareto <- function(InputCollect, OutputModels,
         dt_transformSpendMod[col_name] <- InputCollect$modNLS$yhat[InputCollect$modNLS$yhat$models == 'nls' & InputCollect$modNLS$yhat$channel == channel,"yhat"]
       }
       for (organic_var in InputCollect$organic_vars) {
-        dt_transformSpendMod[[organic_var]] <- NA
+        dt_transformSpendMod[[organic_var]] <- dt_transformPlot[[organic_var]]
+        dt_transformVars[[organic_var]] <- dt_transformPlot[[organic_var]]
       }
 
       dt_transformAdstock <- dt_transformPlot

--- a/R/R/pareto.R
+++ b/R/R/pareto.R
@@ -346,7 +346,7 @@ robyn_pareto <- function(InputCollect, OutputModels,
       dt_transformPlot <- select(dt_mod, .data$ds, all_of(InputCollect$all_media)) # independent variables
       dt_transformSpend <- cbind(dt_transformPlot[, "ds"], InputCollect$dt_input[, c(InputCollect$paid_media_spends)]) # spends of indep vars
       dt_transformVars <- cbind(dt_transformPlot[, "ds"], InputCollect$dt_input[, c(InputCollect$paid_media_vars)])
-      dt_transformSpendMod <- tibble(ds = select(InputCollect$dt_mod,.data$ds))
+      dt_transformSpendMod <- data.frame(ds = select(InputCollect$dt_mod,.data$ds))
       for (i in seq_along(InputCollect$paid_media_vars)) {
         channel <- InputCollect$paid_media_vars[i]
         col_name <- InputCollect$paid_media_spends[i]


### PR DESCRIPTION
## Project Robyn

This pull requests amends the creation of "pareto_alldecomp_matrix.csv".

Main currently produces what I believe are erroneous values against "rawSpend" and "predictedExposure" values in that csv. Regardless of input, the rawSpend and predictedExposure values appear to be always the same as "rawMedia" values (the latter being correct values). 

Having examined previous versions of the code I am reasonably confident that the intended behaviour is to carry the spend values from paid_media_spends as raw data directly into rawSpend. In addition, the predictedExposure values I believe are intended to correspond to the y_hat values which are originally created in fit_spend_exposure. 
 

## Type of change
- fix: Bug fix


## How Has This Been Tested?
I have tested the change by running the following scenarios:
- paid_media_vars is absent/NULL (in this case, behaviour is unchanged to current)
- paid_media_vars is present, no values are equal to paid_media_spend
- paid_media_vars is present, some values are equal to paid_media_spend

I have considered that in some cases yhat values are intended to come from the Michaelis–Menten procedure and in some cases the linear model depending if fit with MM was possible and the comparison of the R^2 values. I have relied on the population of values in InputCollect$modNLS$yhat where currently row values with models=='nls' are actually linear model values according to which model was chosen. 
