### PR TITLE
feat and fix: InputCollect use case for robyn_recreate() + organic_vars added to prophet decomp

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Robyn
 Type: Package
 Title: Semi-Automated Marketing Mix Modeling (MMM) from Meta Marketing Science 
-Version: 3.10.4.9004
+Version: 3.10.4.9005
 Authors@R: c(
     person("Gufeng", "Zhou", , "gufeng@meta.com", c("aut")),
     person("Leonel", "Sentana", , "leonelsentana@meta.com", c("aut")),

--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -733,6 +733,7 @@ robyn_engineering <- function(x, quiet = FALSE, ...) {
       prophet_signs = InputCollect$prophet_signs,
       factor_vars = factor_vars,
       context_vars = InputCollect$context_vars,
+      organic_vars = InputCollect$organic_vars,
       paid_media_spends = paid_media_spends,
       intervalType = InputCollect$intervalType,
       dayInterval = InputCollect$dayInterval,
@@ -773,7 +774,7 @@ robyn_engineering <- function(x, quiet = FALSE, ...) {
 #' @return A list containing all prophet decomposition output.
 prophet_decomp <- function(dt_transform, dt_holidays,
                            prophet_country, prophet_vars, prophet_signs,
-                           factor_vars, context_vars, paid_media_spends,
+                           factor_vars, context_vars, organic_vars, paid_media_spends,
                            intervalType, dayInterval, custom_params) {
   check_prophet(dt_holidays, prophet_country, prophet_vars, prophet_signs, dayInterval)
   recurrence <- select(dt_transform, .data$ds, .data$dep_var) %>% rename("y" = "dep_var")
@@ -785,7 +786,7 @@ prophet_decomp <- function(dt_transform, dt_holidays,
   use_weekday <- "weekday" %in% prophet_vars | "weekly.seasonality" %in% prophet_vars
 
   dt_regressors <- bind_cols(recurrence, select(
-    dt_transform, all_of(c(context_vars, paid_media_spends))
+    dt_transform, all_of(c(paid_media_spends, context_vars, organic_vars))
   )) %>%
     mutate(ds = as.Date(.data$ds))
 

--- a/R/R/json.R
+++ b/R/R/json.R
@@ -278,11 +278,15 @@ Adstock: {a$adstock}
 robyn_recreate <- function(json_file, quiet = FALSE, ...) {
   json <- robyn_read(json_file, quiet = TRUE)
   message(">>> Recreating model ", json$ExportedModel$select_model)
-  InputCollect <- robyn_inputs(
-    json_file = json_file,
-    quiet = quiet,
-    ...
-  )
+  if (!"InputCollect" %in% names(list(...))) {
+    InputCollect <- robyn_inputs(
+      json_file = json_file,
+      quiet = quiet,
+      ...
+    )
+  } else {
+    InputCollect <- list(...)[["InputCollect"]]
+  }
   OutputCollect <- robyn_run(
     InputCollect = InputCollect,
     json_file = json_file,

--- a/R/R/json.R
+++ b/R/R/json.R
@@ -278,22 +278,30 @@ Adstock: {a$adstock}
 robyn_recreate <- function(json_file, quiet = FALSE, ...) {
   json <- robyn_read(json_file, quiet = TRUE)
   message(">>> Recreating model ", json$ExportedModel$select_model)
-  if (!"InputCollect" %in% names(list(...))) {
+  args <- list(...)
+  if (!"InputCollect" %in% names(args)) {
     InputCollect <- robyn_inputs(
       json_file = json_file,
       quiet = quiet,
       ...
     )
+    OutputCollect <- robyn_run(
+      InputCollect = InputCollect,
+      json_file = json_file,
+      export = FALSE,
+      quiet = quiet,
+      ...
+    )
   } else {
-    InputCollect <- list(...)[["InputCollect"]]
+    # Use case: skip feature engineering when InputCollect is provided
+    InputCollect <- args[["InputCollect"]]
+    OutputCollect <- robyn_run(
+      json_file = json_file,
+      export = FALSE,
+      quiet = quiet,
+      ...
+    )
   }
-  OutputCollect <- robyn_run(
-    InputCollect = InputCollect,
-    json_file = json_file,
-    export = FALSE,
-    quiet = quiet,
-    ...
-  )
   return(invisible(list(
     InputCollect = InputCollect,
     OutputCollect = OutputCollect


### PR DESCRIPTION
- **feat**: skip recreating InputCollect if provided on robyn_recreate()
- **fix**: added `organic_vars` to prophet decomposition