### PR TITLE
Fix React warnings/errors.

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -17,66 +17,58 @@ import styles from './styles.module.css';
 
 const features = [
   {
-    title: <>Reduces human bias</>,
+    title: 'Reduces human bias',
     imageUrl: 'img/take_control.svg',
     description: (
-      <>
-        <ul>
-          <li>Automated hyperparameter optimization with evolutionary algorithms from Facebook's AI library <a href="https://facebookresearch.github.io/nevergrad">Nevergrad</a></li>
-          <li>Ridge regression in order to regularize multi-collinearity and prevent overfitting</li>
-          <li>Facebook's <a href="https://facebook.github.io/prophet/">Prophet</a> library to automatically decompose the trend, seasonality and holidays patterns</li>
-        </ul>
-      </>
+      <ul>
+        <li>Automated hyperparameter optimization with evolutionary algorithms from Facebook's AI library <a href="https://facebookresearch.github.io/nevergrad">Nevergrad</a></li>
+        <li>Ridge regression in order to regularize multi-collinearity and prevent overfitting</li>
+        <li>Facebook's <a href="https://facebook.github.io/prophet/">Prophet</a> library to automatically decompose the trend, seasonality and holidays patterns</li>
+      </ul>
     ),
   },
   {
-    title: <>Aligns with the ground-truth</>,
+    title: 'Aligns with the ground-truth',
     imageUrl: 'img/calibrate.svg',
     description: (
-      <>
-        <ul>
-          <li>
-            It calibrates models based on ground-truth methodologies (Geo-based, Facebook lift, MTA, etc.)
-          </li>
-          <li>
-            Facebook <a href="https://facebookresearch.github.io/nevergrad">Nevergrad</a>'s multi-objective optimization minimizing the error between MMM prediction and ground-truth
-          </li>
-        </ul>
-      </>
+      <ul>
+        <li>
+          It calibrates models based on ground-truth methodologies (Geo-based, Facebook lift, MTA, etc.)
+        </li>
+        <li>
+          Facebook <a href="https://facebookresearch.github.io/nevergrad">Nevergrad</a>'s multi-objective optimization minimizing the error between MMM prediction and ground-truth
+        </li>
+      </ul>
     ),
   },
   {
-    title: <>Enables actionable decision making</>,
+    title: 'Enables actionable decision making',
     imageUrl: 'img/focus_on_what_matters.svg',
     description: (
-      <>
-        <ul>
-          <li>
-            Budget allocator using a gradient-based constrained non-linear solver to maximize the outcome by reallocating budgets
-          </li>
-          <li>
-            Enables frequent modeling outcomes due to stronger automation
-          </li>
-          <li>
-            Allows intuitive model comparisons via automatically generated model one-pagers
-          </li>
-        </ul>
-      </>
+      <ul>
+        <li>
+          Budget allocator using a gradient-based constrained non-linear solver to maximize the outcome by reallocating budgets
+        </li>
+        <li>
+          Enables frequent modeling outcomes due to stronger automation
+        </li>
+        <li>
+          Allows intuitive model comparisons via automatically generated model one-pagers
+        </li>
+      </ul>
     ),
   },
   {
-    title: <>Private by Design</>,
+    title: 'Private by Design',
     imageUrl: 'img/security.svg',
     description: (
-      <>
-        <ul>
-          <li>
-            Privacy friendly, with no requirement for PII or Individual log level
-            data
-          </li>
-          <li>Not dependent on Cookies or Pixel data</li>
-        </ul>
-      </>
+      <ul>
+        <li>
+          Privacy friendly, with no requirement for PII or Individual log level
+          data
+        </li>
+        <li>Not dependent on Cookies or Pixel data</li>
+      </ul>
     ),
   },
 ];
@@ -91,7 +83,7 @@ function Feature({ imageUrl, title, description }) {
         </div>
       )}
       <h3>{title}</h3>
-      <p className={styles.descriptionSectionText}>{description}</p>
+      <div className={styles.descriptionSectionText}>{description}</div>
     </div>
   );
 }
@@ -133,9 +125,9 @@ function Home() {
                   width="100%"
                   height="400"
                   src="https://www.youtube.com/embed/8SyKRpsXn44"
-                  frameborder="0"
+                  frameBorder="0"
                   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                  allowfullscreen
+                  allowFullScreen
                 />
               </div>
             </div>


### PR DESCRIPTION
This fixes warnings/errors that React is outputting.

1. `title` was an object, so the same `key` was being set for all elements. There's no need to use JSX for that since you're rendering an `<h3>` anyway, so easy win.
2. `<ul>` isn't a valid DOM child of `<p>` so rendering engines actually move DOM nodes around to make it work, which can break React. Use a `<div>` instead (and remove extra React fragment wrapping).
3. Properly case some attributes on `<iframe>`s