### PR TITLE
fix: crashed cut() when monthly data

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Robyn
 Type: Package
 Title: Semi-Automated Marketing Mix Modeling (MMM) from Meta Marketing Science 
-Version: 3.10.5.9005
+Version: 3.10.5.9006
 Authors@R: c(
     person("Gufeng", "Zhou", , "gufeng@meta.com", c("cre","aut")),
     person("Leonel", "Sentana", , "leonelsentana@meta.com", c("aut")),

--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -986,7 +986,7 @@ set_holidays <- function(dt_transform, dt_holidays, intervalType) {
     }
     holidays <- dt_holidays %>%
       # mutate(ds = cut(.data$ds, intervalType)) %>%
-      mutate(ds = cut(.data$ds, intervalType)) %>%
+      mutate(ds = cut(as.Date(.data$ds, origin = "1970-01-01"), intervalType)) %>%
       select(.data$ds, .data$holiday, .data$country, .data$year) %>%
       group_by(.data$ds, .data$country, .data$year) %>%
       summarise(holiday = paste(.data$holiday, collapse = ", "), n = n())


### PR DESCRIPTION
Issue with holidays data when monthly granularity fixed.
```
Error in mutate(., ds = cut(.data$ds, intervalType)) : 
  ℹ In argument: `ds = cut(.data$ds, intervalType)`.
Caused by error in `cut.default()`:
! 'x' must be numeric
```