### PR TITLE
fix: when all values on a column are negative crash

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Robyn
 Type: Package
 Title: Semi-Automated Marketing Mix Modeling (MMM) from Meta Marketing Science 
-Version: 3.10.5.9006
+Version: 3.10.5.9007
 Authors@R: c(
     person("Gufeng", "Zhou", , "gufeng@meta.com", c("cre","aut")),
     person("Leonel", "Sentana", , "leonelsentana@meta.com", c("aut")),

--- a/R/R/checks.R
+++ b/R/R/checks.R
@@ -50,6 +50,12 @@ check_novar <- function(dt_input, InputCollect = NULL) {
   }
 }
 
+check_allneg <- function(df) {
+  all_negative <- unlist(lapply(df, function(x) all(x <= 0)))
+  df <- mutate_at(df, names(which(all_negative)), function(x) abs(x))
+  return(df)
+}
+
 check_varnames <- function(dt_input, dt_holidays,
                            dep_var, date_var,
                            context_vars, paid_media_spends,

--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -186,11 +186,10 @@ robyn_inputs <- function(dt_input = NULL,
   ### Use case 1: running robyn_inputs() for the first time
   if (is.null(InputCollect)) {
     dt_input <- as_tibble(dt_input)
-    # if (!is.null(dt_holidays)) dt_holidays <- as_tibble(dt_holidays) %>%
-    # mutate(ds = as.Date(.data$ds, origin = "1970-01-01"))
     if (!is.null(dt_holidays)) dt_holidays <- as_tibble(dt_holidays)
 
-    ## Check for NA values
+    ## Check for NA and all negative values
+    dt_input <- check_allneg(dt_input)
     check_nas(dt_input)
     check_nas(dt_holidays)
 
@@ -199,8 +198,7 @@ robyn_inputs <- function(dt_input = NULL,
       dt_input, dt_holidays,
       dep_var, date_var,
       context_vars, paid_media_spends,
-      organic_vars
-    )
+      organic_vars)
 
     ## Check date input (and set dayInterval and intervalType)
     date_input <- check_datevar(dt_input, date_var)


### PR DESCRIPTION
When running `robyn_run()`, if a value contained "only negative values", it returned this error:

```
Error in { : 
  task 1 failed - "arguments imply differing number of rows: 16, 17"
```

Fixed by checking on `robyn_input()` when all values from any column are negative (or zero) and transform it with `abs()`.