### PR TITLE
Add custom outputs (prophet model and input) to InputCollect

### DIFF
--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -862,7 +862,7 @@ prophet_decomp <- function(dt_transform, dt_holidays,
   #! SALLY ADDED CODE
   paste("HELLO PASTE")
   warning("WHAAAAT.. TEST 5:54")
-  
+  this should throw an error
 
   these <- seq_along(unlist(recurrence[, 1]))
   if (use_trend) dt_transform$trend <- forecastRecurrence$trend[these]

--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -863,10 +863,12 @@ prophet_decomp <- function(dt_transform, dt_holidays,
     mod <- fit.prophet(modelRecurrence, dt_regressors)
     forecastRecurrence <- predict(mod, dt_regressors) # prophet::prophet_plot_components(modelRecurrence, forecastRecurrence)
 
-    #! SH
-    message("SH: Adding facebook model to dt_transform")
-    dt_transform$prophet_model <- mod
   }
+
+
+  #! SH
+  message("SH: Adding facebook model to dt_transform$prophet_model")
+  dt_transform$prophet_model <- mod_ohe
 
   these <- seq_along(unlist(recurrence[, 1]))
   if (use_trend) dt_transform$trend <- forecastRecurrence$trend[these]

--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -861,7 +861,7 @@ prophet_decomp <- function(dt_transform, dt_holidays,
 
   #! SALLY ADDED CODE
   paste("HELLO PASTE")
-  warning("WHAAAAT")
+  warning("WHAAAAT.. TEST 5:54")
   
 
   these <- seq_along(unlist(recurrence[, 1]))

--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -860,11 +860,11 @@ prophet_decomp <- function(dt_transform, dt_holidays,
     }
     mod <- fit.prophet(modelRecurrence, dt_regressors)
     forecastRecurrence <- predict(mod, dt_regressors) # prophet::prophet_plot_components(modelRecurrence, forecastRecurrence)
-  }
 
-  #! SALLY ADDED CODE
-  message("SH: Adding facebook model to dt_transform")
-  dt_transform$prophet_model <- mod
+    #! SALLY ADDED CODE
+    message("SH: Adding facebook model to dt_transform")
+    dt_transform$prophet_model <- mod
+  }
 
   these <- seq_along(unlist(recurrence[, 1]))
   if (use_trend) dt_transform$trend <- forecastRecurrence$trend[these]

--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -325,6 +325,8 @@ robyn_inputs <- function(dt_input = NULL,
       adstock = adstock,
       hyperparameters = hyperparameters,
       calibration_input = calibration_input,
+      #! SH
+      prophet_model = NULL,
       custom_params = list(...)
     )
 
@@ -761,8 +763,8 @@ robyn_engineering <- function(x, quiet = FALSE, ...) {
   ################################################################
   #### Finalize enriched input
 
-  #! SALLY ADDED CODE
-  InputCollect[["prophet_model"]] <- dt_transform$prophet_model
+  #! SH
+  InputCollect$prophet_model <- dt_transform$prophet_model
 
   dt_transform <- subset(dt_transform, select = c("ds", "dep_var", InputCollect$all_ind_vars))
   InputCollect[["dt_mod"]] <- dt_transform
@@ -861,7 +863,7 @@ prophet_decomp <- function(dt_transform, dt_holidays,
     mod <- fit.prophet(modelRecurrence, dt_regressors)
     forecastRecurrence <- predict(mod, dt_regressors) # prophet::prophet_plot_components(modelRecurrence, forecastRecurrence)
 
-    #! SALLY ADDED CODE
+    #! SH
     message("SH: Adding facebook model to dt_transform")
     dt_transform$prophet_model <- mod
   }

--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -761,6 +761,9 @@ robyn_engineering <- function(x, quiet = FALSE, ...) {
   ################################################################
   #### Finalize enriched input
 
+  #! SALLY ADDED CODE
+  InputCollect[["prophet_model"]] <- dt_transform$prophet_model
+
   dt_transform <- subset(dt_transform, select = c("ds", "dep_var", InputCollect$all_ind_vars))
   InputCollect[["dt_mod"]] <- dt_transform
   InputCollect[["dt_modRollWind"]] <- dt_transform[rollingWindowStartWhich:rollingWindowEndWhich, ]
@@ -860,8 +863,8 @@ prophet_decomp <- function(dt_transform, dt_holidays,
   }
 
   #! SALLY ADDED CODE
-  message("This is a message from Sally")
-  warning("This is a warning from Sally")
+  message("SH: Adding facebook model to dt_transform")
+  dt_transform$prophet_model <- mod
 
   these <- seq_along(unlist(recurrence[, 1]))
   if (use_trend) dt_transform$trend <- forecastRecurrence$trend[these]

--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -326,7 +326,7 @@ robyn_inputs <- function(dt_input = NULL,
       hyperparameters = hyperparameters,
       calibration_input = calibration_input,
       #! SH
-      prophet_model = NULL,
+      prophet_custom_output = NULL,
       custom_params = list(...)
     )
 
@@ -760,14 +760,14 @@ robyn_engineering <- function(x, quiet = FALSE, ...) {
       custom_params = custom_params
     )
     dt_transform <- dt_transform_original$dt_transform
-    prophet_model <- dt_transform_original$prophet_model
+    prophet_custom_output <- dt_transform_original$prophet_custom_output
   }
 
   ################################################################
   #### Finalize enriched input
 
   #! SH
-  InputCollect$prophet_model <- prophet_model
+  InputCollect$prophet_custom_output <- prophet_custom_output
 
   dt_transform <- subset(dt_transform, select = c("ds", "dep_var", InputCollect$all_ind_vars))
   InputCollect[["dt_mod"]] <- dt_transform
@@ -862,6 +862,8 @@ prophet_decomp <- function(dt_transform, dt_holidays,
     #! SH START
     message("prophet_model assigned from mod_ohe")
     prophet_model <- mod_ohe
+    prophet_input <- dt_ohe
+
     #! SH END
     }
   } else {
@@ -876,6 +878,8 @@ prophet_decomp <- function(dt_transform, dt_holidays,
 
     #! SH START
     message("prophet_model assigned from mod")
+    prophet_model <- mod
+    prophet_input <- dt_regressors
     #! SH END
   }
 
@@ -889,9 +893,12 @@ prophet_decomp <- function(dt_transform, dt_holidays,
 
   # return (dt_transform)
 
-  #! SH START 
+  #! SH START
   # Needed to return multiple objects
-  return(list(dt_transform = dt_transform, prophet_model = prophet_model))
+  prophet_custom_output <- list(prophet_model = prophet_model,
+              prophet_input = prophet_input)
+  return(list(dt_transform = dt_transform,
+              prophet_custom_output = prophet_custom_output))
   #! SH END
 }
 

--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -859,6 +859,11 @@ prophet_decomp <- function(dt_transform, dt_holidays,
     forecastRecurrence <- predict(mod, dt_regressors) # prophet::prophet_plot_components(modelRecurrence, forecastRecurrence)
   }
 
+  #! SALLY ADDED CODE
+  paste("HELLO PASTE")
+  warning("WHAAAAT")
+  
+
   these <- seq_along(unlist(recurrence[, 1]))
   if (use_trend) dt_transform$trend <- forecastRecurrence$trend[these]
   if (use_season) dt_transform$season <- forecastRecurrence$yearly[these]

--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -862,7 +862,7 @@ prophet_decomp <- function(dt_transform, dt_holidays,
   #! SALLY ADDED CODE
   paste("HELLO PASTE")
   warning("WHAAAAT.. TEST 5:54")
-  this should throw an error
+  print("another print statement")
 
   these <- seq_along(unlist(recurrence[, 1]))
   if (use_trend) dt_transform$trend <- forecastRecurrence$trend[these]

--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -861,6 +861,8 @@ prophet_decomp <- function(dt_transform, dt_holidays,
 
     #! SH START
     message("prophet_model assigned from mod_ohe")
+    message("prophet_input assigned from dt_ohe")
+
     prophet_model <- mod_ohe
     prophet_input <- dt_ohe
 
@@ -878,6 +880,7 @@ prophet_decomp <- function(dt_transform, dt_holidays,
 
     #! SH START
     message("prophet_model assigned from mod")
+    message("prophet_input assigned from dt_regressors")
     prophet_model <- mod
     prophet_input <- dt_regressors
     #! SH END

--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -839,9 +839,8 @@ prophet_decomp <- function(dt_transform, dt_holidays,
 
   # dt_regressors <<- dt_regressors
   # modelRecurrence <<- modelRecurrence
-  #! SH START
+  #! SH
   prophet_model <- NULL
-  #! SH END
 
   if (!is.null(factor_vars) && length(factor_vars) > 0) {
     dt_ohe <- dt_regressors %>%

--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -860,9 +860,8 @@ prophet_decomp <- function(dt_transform, dt_holidays,
   }
 
   #! SALLY ADDED CODE
-  paste("HELLO PASTE")
-  warning("WHAAAAT.. TEST 5:54")
-  print("another print statement")
+  message("This is a message from Sally")
+  warning("This is a warning from Sally")
 
   these <- seq_along(unlist(recurrence[, 1]))
   if (use_trend) dt_transform$trend <- forecastRecurrence$trend[these]


### PR DESCRIPTION
# Summary

I forked the Robyn repo and added some extra lines of code to be able to
- Pull the prophet model
- Pull the prophet input data

This is accessed as 
```R
# For the actual model
InputCollect$prophet_custom_output$prophet_model

# For the prophet input (just for debugging purposes to see what went into the model
InputCollect$prophet_custom_output$prophet_input
```

How to actually use the modified code will be shown in a separate PR :) 
