### PR TITLE
Adding python logger config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,11 @@ RobynApp.Rcheck/RobynApp/R/RobynApp.rdb
 RobynApp.Rcheck/RobynApp/R/RobynApp.rdx
 RobynApp_1.0.0.tar.gz
 Robyn_Fork.Rproj
+python/.venv
+python/**/.venv
+python/dist
+python/**/__pycache__
+python/.vscode
+python/src/robynpy.egg-info*
+python/oldportedcode
+

--- a/python/src/robyn/__init__.py
+++ b/python/src/robyn/__init__.py
@@ -1,0 +1,7 @@
+import logging.config
+import datetime
+
+# Get the current datetime
+current_datetime = datetime.datetime.now()
+
+logging.config.fileConfig('logging.conf', defaults={'asctime': current_datetime.strftime('%Y-%m-%d_%H-%M-%S')})

--- a/python/src/robyn/__init__.py
+++ b/python/src/robyn/__init__.py
@@ -1,7 +1,13 @@
 import logging.config
 import datetime
+import os
 
 # Get the current datetime
 current_datetime = datetime.datetime.now()
 
-logging.config.fileConfig('logging.conf', defaults={'asctime': current_datetime.strftime('%Y-%m-%d_%H-%M-%S')})
+#print(os.getcwd())
+
+logging_conf_path = os.path.join(os.path.dirname(__file__), 'common/config/logging.conf')
+
+# Load the logging configuration file
+logging.config.fileConfig(logging_conf_path, defaults={'asctime': current_datetime.strftime('%Y-%m-%d_%H-%M-%S')})

--- a/python/src/robyn/__init__.py
+++ b/python/src/robyn/__init__.py
@@ -1,13 +1,16 @@
-import logging.config
 import datetime
+import logging.config
 import os
 
 # Get the current datetime
 current_datetime = datetime.datetime.now()
 
-#print(os.getcwd())
-
-logging_conf_path = os.path.join(os.path.dirname(__file__), 'common/config/logging.conf')
+logging_conf_path = os.path.join(
+    os.path.dirname(__file__), "common/config/logging.conf"
+)
 
 # Load the logging configuration file
-logging.config.fileConfig(logging_conf_path, defaults={'asctime': current_datetime.strftime('%Y-%m-%d_%H-%M-%S')})
+logging.config.fileConfig(
+    logging_conf_path,
+    defaults={"asctime": current_datetime.strftime("%Y-%m-%d_%H-%M-%S")},
+)

--- a/python/src/robyn/common/config/logging.conf
+++ b/python/src/robyn/common/config/logging.conf
@@ -1,0 +1,29 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=file,console
+
+[formatters]
+keys=simple
+
+[logger_root]
+level=INFO
+handlers=file,console
+qualname=
+
+[handler_file]
+class=FileHandler
+level=INFO
+formatter=simple
+args=('robynpy_%(asctime)s.log', 'w')
+
+[handler_console]
+class=StreamHandler
+level=INFO
+formatter=simple
+args=(sys.stderr,)
+
+[formatter_simple]
+format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
+datefmt=%Y-%m-%d %H:%M:%S

--- a/python/src/robyn/data/validation/calibration_input_validation.py
+++ b/python/src/robyn/data/validation/calibration_input_validation.py
@@ -3,8 +3,6 @@ from robyn.data.entities.mmmdata import MMMData
 from robyn.data.validation.validation import Validation, ValidationResult
 from typing import List
 
-from robyn.modeling.entities.modelrun_trials_config import TrialsConfig
-
 class CalibrationInputValidation(Validation):
     def __init__(self, mmmdata: MMMData, calibration_input: CalibrationInput) -> None:
         self.mmmdata = mmmdata
@@ -23,16 +21,6 @@ class CalibrationInputValidation(Validation):
 
     def check_obj_weight(
         self, calibration_input: CalibrationInput, objective_weights: List[float], refresh: bool
-    ) -> ValidationResult:
-        # method implementation goes here
-        raise NotImplementedError("Not yet implemented")
-
-    def check_iteration(
-        self,
-        calibration_input: CalibrationInput,
-        trials_config: TrialsConfig,
-        hyps_fixed: bool,
-        refresh: bool,
     ) -> ValidationResult:
         # method implementation goes here
         raise NotImplementedError("Not yet implemented")

--- a/python/src/robyn/robyn.py
+++ b/python/src/robyn/robyn.py
@@ -3,6 +3,8 @@
 # TODO This needs to be rewritten to match the new structure of the codebase
 # TODO Add separate methods if state is loaded from robyn_object or json_file for each method
 
+import logging
+
 from robyn.data.entities.calibration_input import CalibrationInput
 from robyn.data.entities.holidays_data import HolidaysData
 from robyn.data.entities.hyperparameters import Hyperparameters
@@ -11,7 +13,6 @@ from robyn.data.validation.calibration_input_validation import CalibrationInputV
 from robyn.data.validation.holidays_data_validation import HolidaysDataValidation
 from robyn.data.validation.hyperparameter_validation import HyperparametersValidation
 from robyn.data.validation.mmmdata_validation import MMMDataValidation
-
 
 
 class Robyn:
@@ -23,6 +24,8 @@ class Robyn:
             working_dir (str): The path to the working directory.
         """
         self.working_dir = working_dir
+        logger = logging.getLogger()
+        logger.info(f"Robyn initialized with working directory: {working_dir}")
 
     # Load input data for the first time and validates
     def initialize(


### PR DESCRIPTION
## Project Robyn

Added Python logger config.
1. robyn/common/config/logger.conf contains logger configuration. Currently it is set to print INFO for both file and console handler
2. log file will be created in current working directory of end usage. for example - log file will be created in tutorials directory if any tutorials is run. (not in working directory specified with instantiation of Robyn)
3. CalibrationInputValidation was broken and it was blocker to test logger changes so fixing it here as well.

## How Has This Been Tested?
<img width="687" alt="image" src="https://github.com/user-attachments/assets/05383581-455b-45c5-9ae3-55fd9c19cd0f">

<img width="746" alt="image" src="https://github.com/user-attachments/assets/9c4af1d0-be6d-4a76-9517-cd996205050b">
