### PR TITLE
feat: cleaner decomp_plot() using cols instead of areas + ref line in 0

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Robyn
 Type: Package
 Title: Semi-Automated Marketing Mix Modeling (MMM) from Meta Marketing Science 
-Version: 3.11.1.9002
+Version: 3.11.1.9003
 Authors@R: c(
     person("Gufeng", "Zhou", , "gufeng@meta.com", c("aut")),
     person("Bernardo", "Lares", , "laresbernardo@gmail.com", c("cre","aut")),

--- a/R/R/plots.R
+++ b/R/R/plots.R
@@ -1588,15 +1588,30 @@ decomp_plot <- function(
     ) %>%
     arrange(abs(.data$value)) %>%
     mutate(variable = factor(.data$variable, levels = unique(.data$variable)))
-  p <- ggplot(df, aes(x = .data$ds, y = .data$value, fill = .data$variable)) +
-    facet_grid(.data$solID ~ .) +
+
+  p <- ggplot(df, aes(x = as.character(ds), y = value, fill = variable)) +
+    facet_grid(solID ~ .) +
     labs(
       title = paste(varType, "Decomposition by Variable"),
       x = NULL, y = paste(intType, varType), fill = NULL
     ) +
-    geom_area() +
+    geom_col(width = 1) +
     theme_lares(background = "white", legend = "right") +
+    geom_hline(yintercept = 0) +
     scale_fill_manual(values = rev(pal[seq(length(unique(df$variable)))])) +
-    scale_y_abbr()
+    scale_y_abbr() +
+    # Must create custom splits because dates is character to be able to be bars
+    scale_x_discrete(
+      breaks = get_evenly_separated_dates(df$ds, n = 6),
+      labels = function(x) format(as.Date(x), "%m/%y")
+    )
   return(p)
+}
+
+get_evenly_separated_dates <- function(dates, n = 6) {
+  dates <- sort(dates)
+  intervals <- n - 1
+  indices <- round(seq(1, length(dates), length.out = n))
+  selected_dates <- dates[indices]
+  return(as.character(selected_dates))
 }

--- a/R/R/plots.R
+++ b/R/R/plots.R
@@ -1586,7 +1586,8 @@ decomp_plot <- function(
   levs <- df %>%
     group_by(.data$variable) %>%
     summarize(impact = sum(abs(.data$value))) %>%
-    arrange(desc(.data$impact)) %>%
+    mutate(is_baseline = grepl("Baseline_L", .data$variable)) %>%
+    arrange(desc(.data$is_baseline), desc(.data$impact)) %>%
     filter(.data$impact > 0) %>%
     pull(.data$variable)
   df <- df %>%


### PR DESCRIPTION
To avoid white spaced and weird plots with spaces when channels impact changed to negative in some periods, migrating plot to columns instead of areas in `decomp_plot()`. Also, added ref line at zero.

See previous and new looks attached for reference. 
![new](https://github.com/user-attachments/assets/bcf1dc2e-405a-48f9-ad53-ce361111f168)
![old](https://github.com/user-attachments/assets/0fb6358f-ce0c-46a9-b743-98dbf4ad716d)

Complexity implementing: date is a continuous value; for columns to have no space between columns, they must be discrete. Solved.