### PR TITLE
Updating pareto-optimizer until it generates plot data

### DIFF
--- a/python/src/robyn/data/entities/mmmdata.py
+++ b/python/src/robyn/data/entities/mmmdata.py
@@ -37,6 +37,9 @@ class MMMData:
             date_var: str = "auto",
             window_start: datetime = None,
             window_end: datetime = None,
+            rolling_window_length: int = None,
+            rolling_window_start_which: int = 0,
+            rolling_window_end_which: int = None,
             paid_media_spends: Optional[List[str]] = None,
             paid_media_vars: Optional[List[str]] = None,
             paid_media_signs: Optional[List[PaidMediaSigns]] = None,
@@ -54,6 +57,9 @@ class MMMData:
             self.date_var: str = date_var
             self.window_start: datetime = window_start
             self.window_end: datetime = window_end
+            self.rolling_window_length: int = rolling_window_length
+            self.rolling_window_start_which: int = rolling_window_start_which
+            self.rolling_window_end_which: int = rolling_window_end_which
             self.paid_media_spends: Optional[List[str]] = paid_media_spends
             self.paid_media_vars: Optional[List[str]] = paid_media_vars
             self.paid_media_signs: Optional[List[str]] = paid_media_signs
@@ -74,6 +80,9 @@ class MMMData:
             date_var: {self.date_var}
             window_start: {self.window_start}
             window_end: {self.window_end}
+            rolling_window_length: {self.rolling_window_length}
+            rolling_window_start_which: {self.rolling_window_start_which}
+            rolling_window_end_which: {self.rolling_window_end_which}
             paid_media_spends: {self.paid_media_spends}
             paid_media_vars: {self.paid_media_vars}
             paid_media_signs: {self.paid_media_signs}

--- a/python/src/robyn/modeling/pareto/hill_calculator.py
+++ b/python/src/robyn/modeling/pareto/hill_calculator.py
@@ -1,0 +1,60 @@
+import pandas as pd
+import numpy as np
+from typing import List, Dict, Any
+
+from robyn.data.entities.mmmdata import MMMData
+from robyn.modeling.entities.modeloutputs import ModelOutputs
+
+class HillCalculator:
+    def __init__(self, mmmdata: MMMData, model_outputs: ModelOutputs, dt_hyppar: pd.DataFrame, dt_coef: pd.DataFrame,
+                 media_spend_sorted: List[str], select_model: str, chn_adstocked: pd.DataFrame = None):
+        self.mmmdata = mmmdata
+        self.model_outputs = model_outputs
+        self.dt_hyppar = dt_hyppar
+        self.dt_coef = dt_coef
+        self.media_spend_sorted = media_spend_sorted
+        self.select_model = select_model
+        self.chn_adstocked = chn_adstocked
+
+    def _get_chn_adstocked_from_output_collect(self) -> pd.DataFrame:
+        # Filter the media_vec_collect DataFrame
+        chn_adstocked = self.model_outputs.media_vec_collect[
+            (self.model_outputs.media_vec_collect['type'] == 'adstockedMedia') &
+            (self.model_outputs.media_vec_collect['solID'] == self.select_model)
+        ]
+        
+        # Select only the required media columns
+        chn_adstocked = chn_adstocked[self.media_spend_sorted]
+        
+        # Slice the DataFrame based on the rolling window
+        start_index = self.mmmdata.mmmdata_spec.window_start
+        end_index = self.mmmdata.mmmdata_spec.window_end
+        chn_adstocked = chn_adstocked.iloc[start_index:end_index+1]
+        
+        return chn_adstocked
+
+    def get_hill_params(self) -> Dict[str, Any]:
+        # Extract alphas and gammas from dt_hyppar
+        hill_hyp_par_vec = self.dt_hyppar.filter(regex='.*_alphas|.*_gammas').iloc[0]
+        alphas = hill_hyp_par_vec[[f"{media}_alphas" for media in self.media_spend_sorted]]
+        gammas = hill_hyp_par_vec[[f"{media}_gammas" for media in self.media_spend_sorted]]
+
+        # Handle chn_adstocked
+        if self.chn_adstocked is None:
+            self.chn_adstocked = self._get_chn_adstocked_from_output_collect()
+
+        # Calculate inflexions
+        inflexions = {}
+        for i, media in enumerate(self.media_spend_sorted):
+            media_range = self.chn_adstocked[media].agg(['min', 'max'])
+            inflexions[media] = np.dot(media_range, [1 - gammas.iloc[i], gammas.iloc[i]])
+
+        # Get sorted coefficients
+        coefs = dict(zip(self.dt_coef['rn'], self.dt_coef['coef']))
+        coefs_sorted = [coefs[media] for media in self.media_spend_sorted]
+
+        return {
+            'alphas': alphas.tolist(),
+            'inflexions': list(inflexions.values()),
+            'coefs_sorted': coefs_sorted
+        }

--- a/python/src/robyn/modeling/pareto/pareto_optimizer.py
+++ b/python/src/robyn/modeling/pareto/pareto_optimizer.py
@@ -3,11 +3,15 @@
 from typing import List, Dict, Optional
 import pandas as pd
 import numpy as np
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
+from functools import partial
 
+from robyn.data.entities.hyperparameters import Hyperparameters
 from robyn.data.entities.mmmdata import MMMData
 from robyn.modeling.entities.modeloutputs import ModelOutputs
-from robyn.modeling.pareto.response_curve import ResponseCurveCalculator
+from robyn.modeling.pareto.hill_calculator import HillCalculator
+from robyn.modeling.pareto.response_curve import ResponseCurveCalculator, ResponseOutput
 from robyn.modeling.pareto.immediate_carryover import ImmediateCarryoverCalculator
 from robyn.modeling.pareto.pareto_utils import ParetoUtils
 
@@ -40,6 +44,13 @@ class ParetoResult:
     df_caov_pct_all: pd.DataFrame
 
 
+@dataclass
+class ParetoData:
+    decomp_spend_dist: pd.DataFrame
+    result_hyp_param: pd.DataFrame
+    x_decomp_agg: pd.DataFrame
+    pareto_fronts: List[int]
+
 class ParetoOptimizer:
     """
     Performs Pareto optimization on marketing mix models.
@@ -55,19 +66,18 @@ class ParetoOptimizer:
         pareto_utils (ParetoUtils): Utility functions for Pareto-related calculations.
     """
 
-    def __init__(self, mmm_data: MMMData, model_outputs: ModelOutputs):
+    def __init__(self, mmm_data: MMMData, model_outputs: ModelOutputs, hyper_parameter: Hyperparameters):
         """
         Initialize the ParetoOptimizer.
 
         Args:
             mmm_data (MMMData): Input data for the marketing mix model.
             model_outputs (ModelOutputs): Output data from the model runs.
+            hyper_parameter (Hyperparameters): Hyperparameters for the model runs.
         """
         self.mmm_data = mmm_data
         self.model_outputs = model_outputs
-        self.response_calculator = ResponseCurveCalculator(mmm_data, model_outputs)
-        self.carryover_calculator = ImmediateCarryoverCalculator(mmm_data, model_outputs)
-        self.pareto_utils = ParetoUtils()
+        self.hyper_parameter = hyper_parameter
 
     def optimize(
         self,
@@ -92,22 +102,25 @@ class ParetoOptimizer:
             ParetoResult: The results of the Pareto optimization process.
         """
         aggregated_data = self._aggregate_model_data(calibrated)
-        pareto_fronts_df = self._compute_pareto_fronts(aggregated_data, pareto_fronts, min_candidates)
-        response_curves = self._compute_response_curves(pareto_fronts_df)
-        plot_data = self._generate_plot_data(pareto_fronts_df, response_curves)
+        aggregated_data['result_hyp_param'] = self._compute_pareto_fronts(aggregated_data, pareto_fronts, min_candidates, calibration_constraint)
+
+        pareto_data = self.prepare_pareto_data(aggregated_data, pareto_fronts, min_candidates)
+        response_curves = self._compute_response_curves(pareto_data)
+        # TODO IMplement
+        plotting_data = self._generate_plot_data(aggregated_data, response_curves)
 
         return ParetoResult(
-            pareto_solutions=pareto_fronts_df["solID"].tolist(),
-            pareto_fronts=len(pareto_fronts_df["pareto_front"].unique()),
+            pareto_solutions=None, # TODO: plotting_data["solID"].tolist(),
+            pareto_fronts=pareto_fronts,
             result_hyp_param=aggregated_data["result_hyp_param"],
-            x_decomp_agg=aggregated_data["x_decomp_agg"],
-            result_calibration=aggregated_data.get("result_calibration"),
-            media_vec_collect=response_curves["media_vec_collect"],
-            x_decomp_vec_collect=response_curves["x_decomp_vec_collect"],
-            plot_data_collect=plot_data,
-            df_caov_pct_all=self.carryover_calculator.calculate_all(),
+            result_calibration=aggregated_data["result_calibration"],
+            x_decomp_agg=pareto_data.x_decomp_agg,
+            media_vec_collect=None, # TODO: plotting_data["media_vec_collect"],
+            x_decomp_vec_collect=None, # TODO: plotting_data["x_decomp_vec_collect"],
+            plot_data_collect=None, # TODO: plotting_data,
+            df_caov_pct_all=None # TODO: plotting_data.df_caov_pct_all,
         )
-
+    
     def _aggregate_model_data(self, calibrated: bool) -> Dict[str, pd.DataFrame]:
         """
         Aggregate and prepare data from model outputs for Pareto optimization.
@@ -124,28 +137,288 @@ class ParetoOptimizer:
                 - 'x_decomp_agg': Aggregated decomposition results
                 - 'result_calibration': Calibration results (if calibrated is True)
         """
-        pass
+        hyper_fixed = self.model_outputs.hyper_fixed
+        # Extract resultCollect from self.model_outputs
+        trials = [model for model in self.model_outputs.trials if hasattr(model, 'resultCollect')]
 
+        # Create lists of resultHypParam and xDecompAgg using list comprehension
+        resultHypParam_list = [trial.result_hyp_param for trial in self.model_outputs.trials]
+        xDecompAgg_list = [trial.x_decomp_agg for trial in self.model_outputs.trials]
+
+        # Concatenate the lists into DataFrames using pd.concat
+        resultHypParam = pd.concat(resultHypParam_list, ignore_index=True)
+        xDecompAgg = pd.concat(xDecompAgg_list, ignore_index=True)
+
+        if calibrated:
+            resultCalibration = pd.concat([pd.DataFrame(trial.liftCalibration) for trial in trials])
+            resultCalibration = resultCalibration.rename(columns={'liftMedia': 'rn'})
+        else:
+            resultCalibration = None
+        if not hyper_fixed:
+            df_names = [resultHypParam, xDecompAgg]
+            if calibrated:
+                df_names.append(resultCalibration)
+            for df in df_names:
+                df['iterations'] = (df['iterNG'] - 1) * self.model_outputs.cores + df['iterPar']
+        elif hyper_fixed and calibrated:
+            df_names = [resultCalibration]
+            for df in df_names:
+                df['iterations'] = (df['iterNG'] - 1) * self.model_outputs.cores + df['iterPar']
+        
+        # Check if recreated model and bootstrap results are available
+        if len(xDecompAgg['solID'].unique()) == 1 and 'boot_mean' not in xDecompAgg.columns:
+            # Get bootstrap results from model_outputs object
+            bootstrap = getattr(self.model_outputs, 'bootstrap', None)
+            if bootstrap is not None:
+                # Merge bootstrap results with xDecompAgg using left join
+                xDecompAgg = pd.merge(xDecompAgg, bootstrap, left_on='rn', right_on='variable')
+        
+        return {
+            'result_hyp_param': resultHypParam,
+            'x_decomp_agg': xDecompAgg,
+            'result_calibration': resultCalibration,
+        }
+
+    
     def _compute_pareto_fronts(
-        self, data: Dict[str, pd.DataFrame], pareto_fronts: str, min_candidates: int
+        self, aggregated_data: Dict[str, pd.DataFrame], pareto_fronts: str, min_candidates: int, calibration_constraint: float
     ) -> pd.DataFrame:
         """
         Calculate Pareto fronts from the aggregated model data.
 
-        This method identifies Pareto-optimal solutions based on specified optimization criteria
-        (typically NRMSE and DECOMP.RSSD) and assigns them to Pareto fronts.
+        This method identifies Pareto-optimal solutions based on NRMSE and DECOMP.RSSD
+        optimization criteria and assigns them to Pareto fronts.
 
         Args:
-            data (Dict[str, pd.DataFrame]): Aggregated model data from _aggregate_model_data.
+            resultHypParamPareto (pd.DataFrame): DataFrame containing model results,
+                                                including 'nrmse' and 'decomp.rssd' columns.
             pareto_fronts (str): Number of Pareto fronts to compute or "auto".
-            min_candidates (int): Minimum number of candidates when using "auto" Pareto fronts.
 
         Returns:
             pd.DataFrame: A dataframe of Pareto-optimal solutions with their corresponding front numbers.
         """
-        pass
+        resultHypParam = aggregated_data['result_hyp_param']
+        xDecompAgg = aggregated_data['x_decomp_agg']
+        resultCalibration = aggregated_data['result_calibration']
 
-    def _compute_response_curves(self, pareto_fronts_df: pd.DataFrame) -> Dict[str, pd.DataFrame]:
+        if not self.model_outputs.hyper_fixed:
+            # Filter and group data to calculate coef0
+            xDecompAggCoef0 = (xDecompAgg[xDecompAgg['rn'].isin(self.mmm_data.mmmdata_spec.paid_media_spends)]
+                            .groupby('solID')['coef']
+                            .apply(lambda x: min(x.dropna()) == 0))
+            # calculate quantiles
+            mape_lift_quantile10 = resultHypParam['mape'].quantile(calibration_constraint)
+            nrmse_quantile90 = resultHypParam['nrmse'].quantile(0.9)
+            decomprssd_quantile90 = resultHypParam['decomp.rssd'].quantile(0.9)
+            # merge resultHypParam with xDecompAggCoef0
+            resultHypParam = pd.merge(resultHypParam, xDecompAggCoef0, on='solID', how='left')
+            # create a new column 'mape.qt10'
+            resultHypParam['mape.qt10'] = (resultHypParam['mape'] <= mape_lift_quantile10) & \
+                                        (resultHypParam['nrmse'] <= nrmse_quantile90) & \
+                                        (resultHypParam['decomp.rssd'] <= decomprssd_quantile90)
+            # filter resultHypParam
+            resultHypParamPareto = resultHypParam[resultHypParam['mape.qt10'] == True]
+            # calculate Pareto front
+            pareto_fronts_df = ParetoOptimizer._pareto_fronts(resultHypParamPareto,
+                                        pareto_fronts=pareto_fronts)
+            # merge resultHypParamPareto with pareto_fronts_df
+            resultHypParamPareto = pd.merge(resultHypParamPareto, pareto_fronts_df, left_on=['nrmse', 'decomp.rssd'], right_on=['x', 'y'])
+            resultHypParamPareto = resultHypParamPareto.rename(columns={'pareto_front': 'robynPareto'})
+            resultHypParamPareto = resultHypParamPareto.sort_values(['iterNG', 'iterPar', 'nrmse'])[['solID', 'robynPareto']]
+            resultHypParamPareto = resultHypParamPareto.groupby('solID').first().reset_index()
+            resultHypParam = pd.merge(resultHypParam, resultHypParamPareto, on='solID', how='left')
+        else:
+            resultHypParam = resultHypParam.assign(mape_qt10=True, robynPareto=1, coef0=np.nan)
+
+        # Calculate combined weighted error scores
+        resultHypParam['error_score'] = ParetoUtils.calculate_errors_scores(df=resultHypParam, ts_validation=self.model_outputs.ts_validation)
+        return resultHypParam
+
+        
+    @staticmethod
+    def _pareto_fronts(resultHypParamPareto: pd.DataFrame, pareto_fronts: str) -> pd.DataFrame:
+        """
+        Calculate Pareto fronts from the aggregated model data.
+
+        This method identifies Pareto-optimal solutions based on NRMSE and DECOMP.RSSD
+        optimization criteria and assigns them to Pareto fronts.
+
+        Args:
+            resultHypParamPareto (pd.DataFrame): DataFrame containing model results,
+                                                including 'nrmse' and 'decomp.rssd' columns.
+            pareto_fronts (Union[str, int]): Number of Pareto fronts to calculate or "auto".
+        """
+        data = pd.DataFrame({'x': resultHypParamPareto['nrmse'], 'y': resultHypParamPareto['decomp.rssd']})
+        data = data.sort_values(by=['x', 'y'], ascending=[True, True])
+        pareto_fronts_df = pd.DataFrame(columns=['x', 'y', 'pareto_front'])
+        i = 1
+
+        while not data.empty and (pareto_fronts == "auto" or i <= int(pareto_fronts)):
+            # Identify Pareto front
+            is_pareto = data.apply(lambda row: all((row['y'] <= data['y']) & (row['x'] <= data['x'])), axis=1)
+            pareto_front = data[is_pareto]
+            pareto_front['pareto_front'] = i
+
+            # Append to result dataframe
+            pareto_fronts_df = pd.concat([pareto_fronts_df, pareto_front])
+
+            # Remove identified Pareto front from data
+            data = data[~is_pareto]
+            i += 1
+        return pareto_fronts_df.reset_index(drop=True)
+
+
+    def prepare_pareto_data(self, aggregated_data: Dict[str, pd.DataFrame], 
+                            pareto_fronts: str, min_candidates: int) -> ParetoData:
+        result_hyp_param = aggregated_data['result_hyp_param']
+        x_decomp_agg = aggregated_data['x_decomp_agg']
+
+        # 1. Binding Pareto results
+        x_decomp_agg = pd.merge(x_decomp_agg, 
+                                result_hyp_param[['robynPareto', 'solID']], 
+                                on='solID', how='left')
+        
+        # Step 1: Collect decomp_spend_dist from each trial and add the trial number
+        decomp_spend_dist = pd.concat([
+            trial.decomp_spend_dist.assign(trial=trial.trial)
+            for trial in self.model_outputs.trials
+            if trial.decomp_spend_dist is not None
+        ], ignore_index=True)
+
+        # Step 2: Add solID if hyper_fixed is False
+        if not self.model_outputs.hyper_fixed:
+            decomp_spend_dist['solID'] = (
+                decomp_spend_dist['trial'].astype(str) + '_' +
+                decomp_spend_dist['iterNG'].astype(str) + '_' +
+                decomp_spend_dist['iterPar'].astype(str)
+            )
+
+        # Step 4: Left join with resultHypParam
+        decomp_spend_dist = pd.merge(
+            decomp_spend_dist,
+            result_hyp_param[['robynPareto', 'solID']],
+            on='solID',
+            how='left'
+        )
+
+        # 2. Preparing for parallel processing
+        # Note: Python parallel processing would be implemented differently
+        # You might want to use multiprocessing or concurrent.futures here
+
+        # 3. Determining the number of Pareto fronts
+        if self.model_outputs.hyper_fixed or len(result_hyp_param) == 1:
+            pareto_fronts = 1
+
+        # 4. Handling automatic Pareto front selection
+        if pareto_fronts == "auto":
+            n_pareto = result_hyp_param['robynPareto'].notna().sum()
+            
+            # Check if any trial has lift_calibration
+            is_calibrated = any(trial.lift_calibration is not None for trial in self.model_outputs.trials)
+
+            if n_pareto <= min_candidates and len(result_hyp_param) > 1 and not is_calibrated:
+                raise ValueError(
+                    f"Less than {min_candidates} candidates in pareto fronts. "
+                    "Increase iterations to get more model candidates or decrease min_candidates."
+                )
+
+            auto_pareto = (result_hyp_param[result_hyp_param['robynPareto'].notna()]
+                        .groupby('robynPareto')
+                        .agg(n=('solID', 'nunique'))
+                        .reset_index()
+                        .sort_values('robynPareto'))
+            
+            auto_pareto['n_cum'] = auto_pareto['n'].cumsum()
+            auto_pareto = auto_pareto[auto_pareto['n_cum'] >= min_candidates].iloc[0]
+
+            print(f">> Automatically selected {auto_pareto['robynPareto']} Pareto-fronts "
+                f"to contain at least {min_candidates} pareto-optimal models ({auto_pareto['n_cum']})")
+
+            pareto_fronts = int(auto_pareto['robynPareto'])
+
+        # 5. Creating Pareto front vector
+        pareto_fronts_vec = list(range(1, pareto_fronts + 1))
+
+        # 6. Filtering data for selected Pareto fronts
+        decomp_spend_dist_pareto = decomp_spend_dist[decomp_spend_dist['robynPareto'].isin(pareto_fronts_vec)]
+        result_hyp_param_pareto = result_hyp_param[result_hyp_param['robynPareto'].isin(pareto_fronts_vec)]
+        x_decomp_agg_pareto = x_decomp_agg[x_decomp_agg['robynPareto'].isin(pareto_fronts_vec)]
+
+        return ParetoData(decomp_spend_dist=decomp_spend_dist_pareto, 
+                          result_hyp_param=result_hyp_param_pareto, 
+                          x_decomp_agg=x_decomp_agg_pareto, 
+                          pareto_fronts=pareto_fronts_vec)
+
+    def run_dt_resp(self, row: pd.Series, paretoData: ParetoData) -> pd.Series:
+        """
+        Calculate response curves for a given row of Pareto data. 
+        This method is used for parallel processing.
+
+        Args:
+            row (pd.Series): A row of Pareto data.
+            paretoData (ParetoData): Pareto data.
+
+        Returns:
+            pd.Series: A row of response curves.
+        """
+        get_solID = row['solID']
+        get_spendname = row['rn']
+        startRW = self.mmm_data.mmmdata_spec.rolling_window_start_which
+        endRW = self.mmm_data.mmmdata_spec.rolling_window_end_which
+
+        response_calculator = ResponseCurveCalculator(
+            mmm_data=self.mmm_data,
+            model_outputs=self.model_outputs,
+            hyperparameter = self.hyper_parameter)
+
+        response_output: ResponseOutput = response_calculator.calculate_response(
+            select_model=get_solID,
+            metric_name=get_spendname,
+            date_range="all",
+            dt_hyppar=paretoData.result_hyp_param,
+            dt_coef=paretoData.x_decomp_agg,
+            quiet=True
+        )
+
+        mean_spend_adstocked = np.mean(response_output.input_total[startRW:endRW])
+        mean_carryover = np.mean(response_output.input_carryover[startRW:endRW])
+        
+        dt_hyppar = paretoData.result_hyp_param[paretoData.result_hyp_param['solID'] == get_solID]
+        chn_adstocked = pd.DataFrame({get_spendname: response_output.input_total[startRW:endRW]})
+        dt_coef = paretoData.x_decomp_agg[
+            (paretoData.x_decomp_agg['solID'] == get_solID) & 
+            (paretoData.x_decomp_agg['rn'] == get_spendname)
+        ][['rn', 'coef']]
+
+        hill_calculator = HillCalculator(
+            mmmdata=self.mmm_data,
+            model_outputs=self.model_outputs,
+            dt_hyppar=dt_hyppar,
+            dt_coef=dt_coef,
+            media_spend_sorted=[get_spendname],
+            select_model=get_solID,
+            chn_adstocked=chn_adstocked
+        )
+        hills = hill_calculator.get_hill_params()
+
+        mean_response = ParetoUtils.calculate_fx_objective(
+            x=row['mean_spend'],
+            coeff=hills['coefs_sorted'][0],
+            alpha=hills['alphas'][0],
+            inflexion=hills['inflexions'][0],
+            x_hist_carryover=mean_carryover,
+            get_sum=False
+        )
+
+        return pd.Series({
+            'mean_response': mean_response,
+            'mean_spend_adstocked': mean_spend_adstocked,
+            'mean_carryover': mean_carryover,
+            'rn': row['rn'],
+            'solID': row['solID']
+        })
+    
+    def _compute_response_curves(self, pareto_data: ParetoData) -> ParetoData:
         """
         Calculate response curves for Pareto-optimal solutions.
 
@@ -153,17 +426,50 @@ class ParetoOptimizer:
         providing insights into the relationship between media spend and response.
 
         Args:
-            pareto_fronts_df (pd.DataFrame): Dataframe of Pareto-optimal solutions.
+            pareto_data (ParetoData): Pareto data.
 
         Returns:
-            Dict[str, pd.DataFrame]: A dictionary containing:
-                - 'media_vec_collect': Collected media vectors for all Pareto-optimal solutions
-                - 'x_decomp_vec_collect': Collected decomposition vectors for all Pareto-optimal solutions
+            ParetoData: Pareto data with updated decomp_spend_dist and x_decomp_agg.
         """
-        pass
+        print(f">>> Calculating response curves for all models' media variables ({len(pareto_data.decomp_spend_dist)})...")
 
+        # Parallel processing
+        run_dt_resp_partial = partial(self.run_dt_resp, 
+                                      paretoData=pareto_data)
+
+        if self.model_outputs.cores > 1:
+            with ProcessPoolExecutor(max_workers=self.model_outputs.cores) as executor:
+                futures = [executor.submit(run_dt_resp_partial, row) for _, row in pareto_data.decomp_spend_dist.iterrows()]
+                resp_collect = pd.DataFrame([f.result() for f in as_completed(futures)])
+        else:
+            resp_collect = pareto_data.decomp_spend_dist.apply(run_dt_resp_partial, axis=1)
+
+        # Merge results
+        pareto_data.decomp_spend_dist = pd.merge(
+            pareto_data.decomp_spend_dist,
+            resp_collect,
+            on=['solID', 'rn'],
+            how='left'
+        )
+        
+        # Calculate ROI and CPA metrics after merging
+        pareto_data.decomp_spend_dist['roi_mean'] = pareto_data.decomp_spend_dist['mean_response'] / pareto_data.decomp_spend_dist['mean_spend']
+        pareto_data.decomp_spend_dist['roi_total'] = pareto_data.decomp_spend_dist['xDecompAgg'] / pareto_data.decomp_spend_dist['total_spend']
+        pareto_data.decomp_spend_dist['cpa_mean'] = pareto_data.decomp_spend_dist['mean_spend'] / pareto_data.decomp_spend_dist['mean_response']
+        pareto_data.decomp_spend_dist['cpa_total'] = pareto_data.decomp_spend_dist['total_spend'] / pareto_data.decomp_spend_dist['xDecompAgg']
+
+        pareto_data.x_decomp_agg = pd.merge(
+            pareto_data.x_decomp_agg,
+            pareto_data.decomp_spend_dist[['rn', 'solID', 'total_spend', 'mean_spend', 'mean_spend_adstocked', 'mean_carryover',
+                               'mean_response', 'spend_share', 'effect_share', 'roi_mean', 'roi_total', 'cpa_total']],
+            on=['solID', 'rn'],
+            how='left'
+        )
+
+        return pareto_data
+    
     def _generate_plot_data(
-        self, pareto_fronts_df: pd.DataFrame, response_curves: Dict[str, pd.DataFrame]
+        self, aggregated_data: Dict[str, pd.DataFrame], response_curves: Dict[str, pd.DataFrame]
     ) -> Dict[str, pd.DataFrame]:
         """
         Prepare data for various plots used in the Pareto analysis.
@@ -178,4 +484,4 @@ class ParetoOptimizer:
         Returns:
             Dict[str, pd.DataFrame]: A dictionary of dataframes, each containing data for a specific plot type.
         """
-        pass
+        return None

--- a/python/src/robyn/modeling/pareto/response_curve.py
+++ b/python/src/robyn/modeling/pareto/response_curve.py
@@ -1,164 +1,327 @@
 # pyre-strict
 
-from typing import Dict, List, Tuple
+from typing import Optional, Union, Literal
+from dataclasses import dataclass
+from enum import Enum
 import numpy as np
 import pandas as pd
-from dataclasses import dataclass
+import matplotlib.pyplot as plt
 from robyn.data.entities.mmmdata import MMMData
 from robyn.modeling.entities.modeloutputs import ModelOutputs
-
-
-@dataclass
-class HillParameters:
-    """
-    Represents the parameters of the Hill function for a specific channel.
-
-    Attributes:
-        alpha (float): The alpha parameter of the Hill function.
-        gamma (float): The gamma parameter of the Hill function.
-    """
-
-    alpha: float
-    gamma: float
-
+from robyn.data.entities.enums import AdstockType
+from robyn.data.entities.hyperparameters import ChannelHyperparameters, Hyperparameters
 
 @dataclass
-class ResponseCurveData:
-    """
-    Represents the response curve data for a specific model and metric.
+class MetricDateInfo:
+    metric_loc: pd.Series
+    date_range_updated: pd.Series
 
-    Attributes:
-        model_id (str): The ID of the model.
-        metric_name (str): The name of the metric.
-        channel (str): The name of the channel.
-        spend_values (np.ndarray): Array of spend values.
-        response_values (np.ndarray): Array of response values corresponding to spend values.
-        hill_params (HillParameters): The Hill function parameters used for the calculation.
-    """
+@dataclass
+class MetricValueInfo:
+    metric_value_updated: np.ndarray
+    all_values_updated: pd.Series
 
-    model_id: str
+@dataclass
+class ResponseOutput:
     metric_name: str
-    channel: str
-    spend_values: np.ndarray
-    response_values: np.ndarray
-    hill_params: HillParameters
+    date: pd.Series
+    input_total: np.ndarray
+    input_carryover: np.ndarray
+    input_immediate: np.ndarray
+    response_total: np.ndarray
+    response_carryover: np.ndarray
+    response_immediate: np.ndarray
+    usecase: str
+    plot: plt.Figure
 
+@dataclass
+class AdstockOutput:
+    x: np.ndarray
+    x_decayed: np.ndarray
+    x_imme: Optional[np.ndarray] = None
+
+class UseCase(str, Enum):
+    ALL_HISTORICAL_VEC = "all_historical_vec"
+    SELECTED_HISTORICAL_VEC = "selected_historical_vec"
+    TOTAL_METRIC_DEFAULT_RANGE = "total_metric_default_range"
+    TOTAL_METRIC_SELECTED_RANGE = "total_metric_selected_range"
+    UNIT_METRIC_DEFAULT_LAST_N = "unit_metric_default_last_n"
+    UNIT_METRIC_SELECTED_DATES = "unit_metric_selected_dates"
 
 class ResponseCurveCalculator:
-    """
-    Calculates response curves for marketing mix models.
+    def __init__(self, mmm_data: MMMData, model_outputs: ModelOutputs, hyperparameter: Hyperparameters):
+        self.mmm_data: MMMData = mmm_data
+        self.model_outputs: ModelOutputs = model_outputs
+        self.hyperparameter: Hyperparameters = hyperparameter
 
-    This class handles the calculation of response curves for different models and metrics,
-    including the retrieval of Hill function parameters and the calculation of response values.
+    def calculate_response(self, 
+                           select_model: str,
+                           metric_name: str,
+                           metric_value: Optional[Union[float, list[float]]] = None,
+                           date_range: Optional[str] = None,
+                           quiet: bool = False,
+                           dt_hyppar: pd.DataFrame = pd.DataFrame(),
+                           dt_coef: pd.DataFrame = pd.DataFrame()
+                        ) -> ResponseOutput:
+        # Determine the use case based on input parameters
+        usecase = self._which_usecase(metric_value, date_range)
+        
+        # Check the metric type (spend, exposure, organic)
+        metric_type = self._check_metric_type(metric_name)
+        
+        all_dates = self.mmm_data.data[self.mmm_data.mmmdata_spec.date_var]
+        all_values = self.mmm_data.data[metric_name]
+        
+        # Check and process date range
+        ds_list = self._check_metric_dates(date_range, all_dates, quiet)
+        
+        # Check and process metric values
+        val_list = self._check_metric_value(metric_value, metric_name, all_values, ds_list.metric_loc)
+        
+        date_range_updated = ds_list.date_range_updated
+        metric_value_updated = val_list.metric_value_updated
+        all_values_updated = val_list.all_values_updated
 
-    Attributes:
-        mmm_data (MMMData): Input data for the marketing mix model.
-        model_outputs (ModelOutputs): Output data from the model runs.
-    """
+        # Transform exposure to spend if necessary
+        if metric_type == "exposure":
+            all_values_updated = self._transform_exposure_to_spend(metric_name, metric_value_updated, all_values_updated, ds_list.metric_loc)
+            hpm_name = self._get_spend_name(metric_name)
+        else:
+            hpm_name = metric_name
 
-    def __init__(self, mmm_data: MMMData, model_outputs: ModelOutputs):
-        """
-        Initialize the ResponseCurveCalculator.
+        media_vec_origin = self.mmm_data.data[metric_name]
 
-        Args:
-            mmm_data (MMMData): Input data for the marketing mix model.
-            model_outputs (ModelOutputs): Output data from the model runs.
-        """
-        self.mmm_data = mmm_data
-        self.model_outputs = model_outputs
+        # Get adstock parameters and apply adstock transformation
+        adstock_params = self._get_adstock_params(select_model, hpm_name, dt_hyppar)
+        x_list = self._transform_adstock(media_vec_origin, adstock_params)
+        m_adstocked = x_list.x_decayed
 
-    def calculate_response(
-        self, model_id: str, metric_name: str, channel: str, date_range: Tuple[str, str] = ("all", "all")
-    ) -> ResponseCurveData:
-        """
-        Calculate response curve for a given model, metric, and channel.
+        x_list_sim = self._transform_adstock(all_values_updated, adstock_params)
+        media_vec_sim = x_list_sim.x_decayed
+        
+        input_total = media_vec_sim[ds_list.metric_loc]
+        if self.hyperparameter.adstock == AdstockType.WEIBULL_PDF:
+            media_vec_sim_imme = x_list_sim.x_imme
+            input_immediate = media_vec_sim_imme[ds_list.metric_loc]
+        else:
+            input_immediate = x_list_sim.x[ds_list.metric_loc]
+        input_carryover = input_total - input_immediate
 
-        Args:
-            model_id (str): ID of the model to use.
-            metric_name (str): Name of the metric to calculate response for.
-            channel (str): Name of the channel to calculate response for.
-            date_range (Tuple[str, str]): Start and end dates for the calculation. Use "all" for entire date range.
+        # Get saturation parameters and apply saturation
+        hill_params = self._get_saturation_params(select_model, hpm_name, dt_hyppar)
+        
+        m_adstockedRW = m_adstocked[self.mmm_data.mmmdata_spec.rolling_window_start_which:self.mmm_data.mmmdata_spec.rolling_window_end_which]
+        
+        if usecase == UseCase.ALL_HISTORICAL_VEC:
+            metric_saturated_total = self._saturation_hill(m_adstockedRW, hill_params)
+            metric_saturated_carryover = self._saturation_hill(m_adstockedRW, hill_params)
+        else:
+            metric_saturated_total = self._saturation_hill(m_adstockedRW, hill_params, x_marginal=input_total)
+            metric_saturated_carryover = self._saturation_hill(m_adstockedRW, hill_params, x_marginal=input_carryover)
+        
+        metric_saturated_immediate = metric_saturated_total - metric_saturated_carryover
 
-        Returns:
-            ResponseCurveData: Object containing the response curve data.
-        """
-        hill_params = self._get_hill_params(model_id, channel)
-        spend_values = self._get_spend_values(channel, date_range)
-        response_values = self._calculate_response_values(hill_params, spend_values)
+        # Calculate final response values
+        coeff = dt_coef[(dt_coef['solID'] == select_model) & (dt_coef['rn'] == hpm_name)]['coef'].values[0]
+        m_saturated = self._saturation_hill(m_adstockedRW, hill_params)
+        m_response = m_saturated * coeff
+        response_total = metric_saturated_total * coeff
+        response_carryover = metric_saturated_carryover * coeff
+        response_immediate = response_total - response_carryover
 
-        return ResponseCurveData(
-            model_id=model_id,
+        # TODO: Move this logic out to Visualizers (also not needed every time calculate_response is called for ex, in pareto)
+        # Create response plot
+        # plot = self._create_response_plot(m_adstockedRW, m_response, input_total, response_total, 
+        #                                   input_carryover, response_carryover, input_immediate, 
+        #                                   response_immediate, metric_name, metric_type, date_range_updated)
+
+        return ResponseOutput(
             metric_name=metric_name,
-            channel=channel,
-            spend_values=spend_values,
-            response_values=response_values,
-            hill_params=hill_params,
+            date=date_range_updated,
+            input_total=input_total,
+            input_carryover=input_carryover,
+            input_immediate=input_immediate,
+            response_total=response_total,
+            response_carryover=response_carryover,
+            response_immediate=response_immediate,
+            usecase=usecase,
+            plot=None # TODO: add the call to visualizer here
         )
 
-    def calculate_all_responses(self, model_id: str) -> List[ResponseCurveData]:
-        """
-        Calculate response curves for all channels in a given model.
 
-        Args:
-            model_id (str): ID of the model to use.
+    def _which_usecase(self, metric_value: Optional[Union[float, list[float]]], date_range: Optional[str]) -> UseCase:
+        if metric_value is None:
+            return UseCase.ALL_HISTORICAL_VEC if date_range is None or date_range == "all" else UseCase.SELECTED_HISTORICAL_VEC
+        elif isinstance(metric_value, (int, float)):
+            return UseCase.TOTAL_METRIC_DEFAULT_RANGE if date_range is None else UseCase.TOTAL_METRIC_SELECTED_RANGE
+        elif isinstance(metric_value, (list, np.ndarray)):
+            return UseCase.UNIT_METRIC_DEFAULT_LAST_N if date_range is None else UseCase.UNIT_METRIC_SELECTED_DATES
+        else:
+            raise ValueError(f"Invalid metric_value type: {type(metric_value)}")
 
-        Returns:
-            List[ResponseCurveData]: List of response curve data for each channel.
-        """
-        channels = self._get_model_channels(model_id)
-        return [self.calculate_response(model_id, "default_metric", channel) for channel in channels]
+    def _check_metric_type(self, metric_name: str) -> Literal["spend", "exposure", "organic"]:
+        if metric_name in self.mmm_data.mmmdata_spec.paid_media_spends:
+            return "spend"
+        elif metric_name in self.mmm_data.mmmdata_spec.paid_media_vars:
+            return "exposure"
+        elif metric_name in self.mmm_data.mmmdata_spec.organic_vars:
+            return "organic"
+        else:
+            raise ValueError(f"Unknown metric type for {metric_name}")
 
-    def _get_hill_params(self, model_id: str, channel: str) -> HillParameters:
-        """
-        Get Hill function parameters for a specific model and channel.
+    def _check_metric_dates(self, date_range: Optional[str], all_dates: pd.Series, quiet: bool) -> MetricDateInfo:
+        start_rw = self.mmm_data.mmmdata_spec.rolling_window_start_which
+        end_rw = self.mmm_data.mmmdata_spec.rolling_window_end_which
 
-        Args:
-            model_id (str): ID of the model.
-            channel (str): Name of the channel.
+        if date_range == "all" or date_range is None:
+            metric_loc = slice(start_rw, end_rw)
+            date_range_updated = all_dates[metric_loc]
+        elif date_range.startswith("last_"):
+            n_periods = int(date_range.split("_")[1])
+            metric_loc = slice(end_rw - n_periods + 1, end_rw)
+            date_range_updated = all_dates[metric_loc]
+        elif isinstance(date_range, list) and len(date_range) == 2:
+            start_date, end_date = pd.to_datetime(date_range)
+            metric_loc = (all_dates >= start_date) & (all_dates <= end_date)
+            date_range_updated = all_dates[metric_loc]
+        else:
+            raise ValueError(f"Invalid date_range: {date_range}")
 
-        Returns:
-            HillParameters: Hill function parameters.
-        """
-        # Implementation here
-        pass
+        if not quiet:
+            print(f"Using date range: {date_range_updated.iloc[0]} to {date_range_updated.iloc[-1]}")
 
-    def _get_spend_values(self, channel: str, date_range: Tuple[str, str]) -> np.ndarray:
-        """
-        Get spend values for a channel within the specified date range.
+        return MetricDateInfo(metric_loc=metric_loc, date_range_updated=date_range_updated)
 
-        Args:
-            channel (str): Name of the channel.
-            date_range (Tuple[str, str]): Start and end dates for the data.
+    def _check_metric_value(self, metric_value: Optional[Union[float, list[float]]], 
+                            metric_name: str, all_values: pd.Series, metric_loc: Union[slice, pd.Series]) -> MetricValueInfo:
+        # if isinstance(metric_loc, slice):
+        #     selected_values = all_values.iloc[metric_loc]
+        # elif isinstance(metric_loc, pd.Series):
+        #     selected_values = all_values[metric_loc]
+        # else:  # metric_loc is a list of dates
+        #     selected_values = all_values[all_values.index.isin(metric_loc)]
 
-        Returns:
-            np.ndarray: Array of spend values.
-        """
-        # Implementation here
-        pass
+        if metric_value is None:
+            metric_value_updated = all_values[metric_loc]
+        elif isinstance(metric_value, (int, float)):
+            metric_value_updated = np.full(len(all_values[metric_loc]), metric_value)
+        else:
+            metric_value_updated = np.array(metric_value)
+            if len(metric_value_updated) != len(all_values[metric_loc]):
+                raise ValueError(f"Length of metric_value ({len(metric_value_updated)}) does not match the selected date range ({len(all_values[metric_loc])})")
 
-    def _calculate_response_values(self, hill_params: HillParameters, spend_values: np.ndarray) -> np.ndarray:
-        """
-        Calculate response values using Hill function parameters.
+        all_values_updated = all_values.copy()
+        all_values_updated[metric_loc] = metric_value_updated
 
-        Args:
-            hill_params (HillParameters): Hill function parameters.
-            spend_values (np.ndarray): Array of spend values.
+        return MetricValueInfo(metric_value_updated=metric_value_updated, all_values_updated=all_values_updated)
 
-        Returns:
-            np.ndarray: Array of calculated response values.
-        """
-        # Implementation here
-        pass
+    def _transform_exposure_to_spend(self, metric_name: str, metric_value_updated: np.ndarray, 
+                                     all_values_updated: pd.Series, metric_loc: Union[slice, pd.Series]) -> pd.Series:
+        spend_name = self._get_spend_name(metric_name)
+        spend_expo_mod = self.mmm_data.mmmdata_spec.modNLS['results']
+        temp = spend_expo_mod[spend_expo_mod['channel'] == metric_name]
+        
+        if temp['rsq_nls'].values[0] > temp['rsq_lm'].values[0]:
+            # Use non-linear least squares model
+            Vmax = temp['Vmax'].values[0]
+            Km = temp['Km'].values[0]
+            input_immediate = Km * metric_value_updated / (Vmax - metric_value_updated)
+        else:
+            # Use linear model
+            coef_lm = temp['coef_lm'].values[0]
+            input_immediate = metric_value_updated / coef_lm
 
-    def _get_model_channels(self, model_id: str) -> List[str]:
-        """
-        Get the list of channels for a specific model.
+        all_values_updated[metric_loc] = input_immediate
+        return all_values_updated
 
-        Args:
-            model_id (str): ID of the model.
+    def _get_spend_name(self, metric_name: str) -> str:
+        return self.mmm_data.mmmdata_spec.paid_media_spends[
+            self.mmm_data.mmmdata_spec.paid_media_vars.index(metric_name)]
 
-        Returns:
-            List[str]: List of channel names.
-        """
-        # Implementation here
-        pass
+    def _get_adstock_params(self, select_model: str, hpm_name: str, dt_hyppar: pd.DataFrame) -> ChannelHyperparameters:
+        adstock_type = self.hyperparameter.adstock
+        params = ChannelHyperparameters()
+        
+        if adstock_type == AdstockType.GEOMETRIC:
+            params.thetas = dt_hyppar[dt_hyppar['solID'] == select_model][f"{hpm_name}_thetas"].values[0]
+        elif adstock_type in [AdstockType.WEIBULL, AdstockType.WEIBULL_CDF, AdstockType.WEIBULL_PDF]:
+            params.shapes = dt_hyppar[dt_hyppar['solID'] == select_model][f"{hpm_name}_shapes"].values[0]
+            params.scales = dt_hyppar[dt_hyppar['solID'] == select_model][f"{hpm_name}_scales"].values[0]
+        
+        return params
+
+    # TODO: Move this to transform.py
+    def _transform_adstock(self, x: np.ndarray, params: ChannelHyperparameters) -> AdstockOutput:
+        adstock_type = self.hyperparameter.adstock
+        if adstock_type == AdstockType.GEOMETRIC:
+            x_decayed = self._geometric_adstock(x, params.thetas)
+            return AdstockOutput(x=x, x_decayed=x_decayed)
+        elif adstock_type == AdstockType.WEIBULL_CDF:
+            x_decayed = self._weibull_adstock(x, params.shapes, params.scales, cumulative=True)
+            return AdstockOutput(x=x, x_decayed=x_decayed)
+        elif adstock_type == AdstockType.WEIBULL_PDF:
+            x_decayed, x_imme = self._weibull_adstock(x, params.shapes, params.scales, cumulative=False)
+            return AdstockOutput(x=x, x_decayed=x_decayed, x_imme=x_imme)
+
+    def _geometric_adstock(self, x: np.ndarray, theta: float) -> np.ndarray:
+        return np.convolve(x, theta**np.arange(len(x)))[:len(x)]
+
+    def _weibull_adstock(self, x: np.ndarray, shape: float, scale: float, cumulative: bool) -> Union[np.ndarray, tuple[np.ndarray, np.ndarray]]:
+        n = len(x)
+        weights = np.array([scale * (((i + 1) / scale) ** (shape - 1)) * np.exp(-((i + 1) / scale) ** shape) for i in range(n)])
+        
+        if cumulative:
+            weights = 1 - np.exp(-((np.arange(1, n+1) / scale) ** shape))
+        
+        x_decayed = np.convolve(x, weights)[:n]
+        
+        if cumulative:
+            return x_decayed
+        else:
+            x_imme = x * weights[0]
+            return x_decayed, x_imme
+    
+    def _get_saturation_params(self, select_model: str, hpm_name: str, dt_hyppar: pd.DataFrame) -> ChannelHyperparameters:
+        params = ChannelHyperparameters()
+        params.alphas = dt_hyppar[dt_hyppar['solID'] == select_model][f"{hpm_name}_alphas"].values[0]
+        params.gammas = dt_hyppar[dt_hyppar['solID'] == select_model][f"{hpm_name}_gammas"].values[0]
+        return params
+
+    def _saturation_hill(self, x: np.ndarray, hill_params: ChannelHyperparameters, x_marginal: Optional[np.ndarray] = None) -> np.ndarray:
+        alpha, gamma = hill_params.alphas, hill_params.gammas
+        if x_marginal is None:
+            return x**gamma / (x**gamma + alpha**gamma)
+        else:
+            return (x + x_marginal)**gamma / ((x + x_marginal)**gamma + alpha**gamma) - x**gamma / (x**gamma + alpha**gamma)
+
+    def _create_response_plot(self, m_adstockedRW: np.ndarray, m_response: np.ndarray, 
+                              input_total: np.ndarray, response_total: np.ndarray,
+                              input_carryover: np.ndarray, response_carryover: np.ndarray,
+                              input_immediate: np.ndarray, response_immediate: np.ndarray,
+                              metric_name: str, metric_type: Literal["spend", "exposure", "organic"], 
+                              date_range_updated: pd.Series) -> plt.Figure:
+        fig, ax = plt.subplots(figsize=(10, 6))
+    
+        ax.plot(m_adstockedRW, m_response, color='steelblue', label='Response curve')
+        ax.scatter(input_total, response_total, color='red', s=50, label='Total response')
+        
+        if len(np.unique(input_total)) == 1:
+            ax.scatter(input_carryover, response_carryover, color='green', s=50, marker='s', label='Carryover response')
+            ax.scatter(input_immediate, response_immediate, color='orange', s=50, marker='^', label='Immediate response')
+
+        ax.set_xlabel('Input')
+        ax.set_ylabel('Response')
+        ax.set_title(f"Saturation curve of {'organic' if metric_type == 'organic' else 'paid'} media: {metric_name}")
+        ax.legend()
+        
+        if len(np.unique(input_total)) == 1:
+            subtitle = (f"Carryover Response: {response_carryover[0]:.2f} @ Input {input_carryover[0]:.2f}\n"
+                        f"Immediate Response: {response_immediate[0]:.2f} @ Input {input_immediate[0]:.2f}\n"
+                        f"Total (C+I) Response: {response_total[0]:.2f} @ Input {input_total[0]:.2f}")
+            ax.text(0.05, 0.95, subtitle, transform=ax.transAxes, verticalalignment='top', fontsize=9)
+        
+        plt.figtext(0.5, 0.01, 
+                    f"Response period: {date_range_updated.iloc[0]} to {date_range_updated.iloc[-1]} [{len(date_range_updated)} periods]", 
+                    ha="center", fontsize=8)
+        
+        return fig

--- a/python/src/tutorials/tutorial4_pareto.ipynb
+++ b/python/src/tutorials/tutorial4_pareto.ipynb
@@ -1,0 +1,304 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/funny/Documents/git/Robyn/.venv/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Test Pareto Optimizer\n",
+    "\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from datetime import datetime, timedelta\n",
+    "from robyn.data.entities.mmmdata import MMMData\n",
+    "from robyn.modeling.entities.modeloutputs import ModelOutputs, Trial\n",
+    "from robyn.modeling.pareto.pareto_optimizer import ParetoOptimizer\n",
+    "from robyn.data.entities.enums import DependentVarType, PaidMediaSigns, OrganicSigns, ContextSigns\n",
+    "\n",
+    "from utils.data_mapper import import_data, load_data_from_json\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>facebook_S_alphas</th>\n",
+       "      <th>facebook_S_gammas</th>\n",
+       "      <th>facebook_S_thetas</th>\n",
+       "      <th>newsletter_alphas</th>\n",
+       "      <th>newsletter_gammas</th>\n",
+       "      <th>newsletter_thetas</th>\n",
+       "      <th>ooh_S_alphas</th>\n",
+       "      <th>ooh_S_gammas</th>\n",
+       "      <th>ooh_S_thetas</th>\n",
+       "      <th>print_S_alphas</th>\n",
+       "      <th>print_S_gammas</th>\n",
+       "      <th>print_S_thetas</th>\n",
+       "      <th>search_S_alphas</th>\n",
+       "      <th>search_S_gammas</th>\n",
+       "      <th>search_S_thetas</th>\n",
+       "      <th>tv_S_alphas</th>\n",
+       "      <th>tv_S_gammas</th>\n",
+       "      <th>tv_S_thetas</th>\n",
+       "      <th>train_size</th>\n",
+       "      <th>lambda</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.5</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>0.1</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>0.1</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>0.1</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.4</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.4</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.4</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.8</td>\n",
+       "      <td>0.8</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   facebook_S_alphas  facebook_S_gammas  facebook_S_thetas  newsletter_alphas  \\\n",
+       "0                0.5                0.3                0.0                0.5   \n",
+       "1                3.0                1.0                0.3                3.0   \n",
+       "\n",
+       "   newsletter_gammas  newsletter_thetas  ooh_S_alphas  ooh_S_gammas  \\\n",
+       "0                0.3                0.1           0.5           0.3   \n",
+       "1                1.0                0.4           3.0           1.0   \n",
+       "\n",
+       "   ooh_S_thetas  print_S_alphas  print_S_gammas  print_S_thetas  \\\n",
+       "0           0.1             0.5             0.3             0.1   \n",
+       "1           0.4             3.0             1.0             0.4   \n",
+       "\n",
+       "   search_S_alphas  search_S_gammas  search_S_thetas  tv_S_alphas  \\\n",
+       "0              0.5              0.3              0.0          0.5   \n",
+       "1              3.0              1.0              0.3          3.0   \n",
+       "\n",
+       "   tv_S_gammas  tv_S_thetas  train_size  lambda  \n",
+       "0          0.3          0.3         0.5       0  \n",
+       "1          1.0          0.8         0.8       1  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Load data from JSON\n",
+    "loaded_data = load_data_from_json(\n",
+    "    \"/Users/funny/Documents/git/Robyn/python/src/tutorials/resources/test_data.json\"\n",
+    "    # \"/Users/funny/Downloads/exported_data.json\"\n",
+    ")\n",
+    "imported_data = import_data(loaded_data)\n",
+    "model_outputs = imported_data[\"model_outputs\"]\n",
+    "display((model_outputs.hyper_bound_ng))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "mmm_data = imported_data[\"mmm_data\"]\n",
+    "# display(mmm_data.data.head())\n",
+    "# Display Model Outputs\n",
+    "\n",
+    "model_outputs = imported_data[\"model_outputs\"]\n",
+    "# display((model_outputs.trials[0].result_hyp_param))\n",
+    "\n",
+    "hyperparameters = imported_data[\"hyperparameters\"]\n",
+    "# display(hyperparameters)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">>> Calculating response curves for all models' media variables (10080)...\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "# 3. Create ParetoOptimizer instance\n",
+    "pareto_optimizer = ParetoOptimizer(mmm_data, model_outputs, hyperparameters)\n",
+    "\n",
+    "# 4. Run optimize function\n",
+    "pareto_result = pareto_optimizer.optimize(pareto_fronts=\"auto\", min_candidates=3)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pareto Optimization Results:\n",
+      "Number of Pareto fronts: auto\n",
+      "\n",
+      "Pareto-optimal solutions:\n",
+      "(2016, 43)\n",
+      "\n",
+      "Aggregated decomposition results:\n",
+      "                   rn          coef    xDecompAgg  xDecompPerc  \\\n",
+      "0         (Intercept)  1.490415e+06  2.339952e+08     0.838459   \n",
+      "1               trend  8.526674e-02  2.385925e+07     0.085493   \n",
+      "2              season  3.145922e-02  1.151622e+04     0.000041   \n",
+      "3             holiday  2.209385e-02  1.538306e+05     0.000551   \n",
+      "4  competitor_sales_B  1.061375e-02  9.247092e+06     0.033134   \n",
+      "\n",
+      "   xDecompMeanNon0  xDecompMeanNon0Perc  xDecompAggRF  xDecompPercRF  \\\n",
+      "0     1.490415e+06             0.836026  2.339952e+08       0.838459   \n",
+      "1     1.519697e+05             0.085245  2.385925e+07       0.085493   \n",
+      "2     7.335169e+01             0.000041  1.151622e+04       0.000041   \n",
+      "3     6.153226e+03             0.003452  1.538306e+05       0.000551   \n",
+      "4     5.889868e+04             0.033038  9.247092e+06       0.033134   \n",
+      "\n",
+      "   xDecompMeanNon0RF  xDecompMeanNon0PercRF  ...  total_spend  mean_spend  \\\n",
+      "0       1.490415e+06               0.836026  ...          NaN         NaN   \n",
+      "1       1.519697e+05               0.085245  ...          NaN         NaN   \n",
+      "2       7.335169e+01               0.000041  ...          NaN         NaN   \n",
+      "3       6.153226e+03               0.003452  ...          NaN         NaN   \n",
+      "4       5.889868e+04               0.033038  ...          NaN         NaN   \n",
+      "\n",
+      "   mean_spend_adstocked  mean_carryover  mean_response  spend_share  \\\n",
+      "0                   NaN             NaN            NaN          NaN   \n",
+      "1                   NaN             NaN            NaN          NaN   \n",
+      "2                   NaN             NaN            NaN          NaN   \n",
+      "3                   NaN             NaN            NaN          NaN   \n",
+      "4                   NaN             NaN            NaN          NaN   \n",
+      "\n",
+      "   effect_share  roi_mean  roi_total  cpa_total  \n",
+      "0           NaN       NaN        NaN        NaN  \n",
+      "1           NaN       NaN        NaN        NaN  \n",
+      "2           NaN       NaN        NaN        NaN  \n",
+      "3           NaN       NaN        NaN        NaN  \n",
+      "4           NaN       NaN        NaN        NaN  \n",
+      "\n",
+      "[5 rows x 40 columns]\n",
+      "\n",
+      "All assertions passed. The optimize function is working as expected.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 5. Check results\n",
+    "print(\"Pareto Optimization Results:\")\n",
+    "print(f\"Number of Pareto fronts: {pareto_result.pareto_fronts}\")\n",
+    "print(\"\\Hyper parameter solutions:\")\n",
+    "print(pareto_result.result_hyp_param.head())\n",
+    "\n",
+    "print(\"\\nAggregated decomposition results:\")\n",
+    "print(pareto_result.x_decomp_agg.head())\n",
+    "\n",
+    "# 6. Validate logic\n",
+    "assert pareto_result.pareto_fronts == \"auto\" or isinstance(pareto_result.pareto_fronts, int), \"Invalid pareto_fronts value\"\n",
+    "assert not pareto_result.result_hyp_param.empty, \"Empty result_hyp_param DataFrame\"\n",
+    "assert not pareto_result.x_decomp_agg.empty, \"Empty x_decomp_agg DataFrame\"\n",
+    "\n",
+    "print(\"\\nAll assertions passed. The optimize function is working as expected.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/python/tests/modeling_pareto/test_pareto_utils.py
+++ b/python/tests/modeling_pareto/test_pareto_utils.py
@@ -1,0 +1,68 @@
+import pytest
+import pandas as pd
+import numpy as np
+from src.robyn.modeling.pareto.pareto_utils import ParetoUtils
+
+@pytest.fixture
+def test_data():
+    return pd.DataFrame({
+        'nrmse_test': [0.1, 0.2, 0.3, 0.4, 0.5, np.inf],
+        'nrmse_train': [0.15, 0.25, 0.35, 0.45, 0.55, 0.65],
+        'decomp.rssd': [0.2, 0.3, 0.4, 0.5, 0.6, np.inf],
+        'mape': [0.05, 0.1, 0.15, 0.2, 0.25, np.nan]
+    })
+
+def test_calculate_errors_scores_default(test_data):
+    result = ParetoUtils.calculate_errors_scores(test_data)
+    expected = np.array([0., 0.1443376, 0.2886751, 0.4330127, 0.5773503, 0.4714045])
+    np.testing.assert_almost_equal(result, expected, decimal=2)
+
+def test_calculate_errors_scores_custom_balance(test_data):
+    result = ParetoUtils.calculate_errors_scores(test_data, balance=[2, 1, 1])
+    expected = np.array([0., 0.1545743, 0.3091487, 0.4637231, 0.6182975, 0.5590170])
+    np.testing.assert_almost_equal(result, expected, decimal=2)
+
+def test_calculate_errors_scores_ts_validation_false(test_data):
+    result = ParetoUtils.calculate_errors_scores(test_data, ts_validation=False)
+    expected = np.array([0., 0.1361372, 0.2722745, 0.4082483, 0.5443118, 0.4714045])
+    np.testing.assert_almost_equal(result, expected, decimal=2)
+
+def test_calculate_errors_scores_all_infinite():
+    inf_data = pd.DataFrame({
+        'nrmse_test': [np.inf, np.inf],
+        'nrmse_train': [np.inf, np.inf],
+        'decomp.rssd': [np.inf, np.inf],
+        'mape': [np.inf, np.inf]
+    })
+    result = ParetoUtils.calculate_errors_scores(inf_data)
+    expected = np.array([0.0, 0.0])
+    np.testing.assert_almost_equal(result, expected, decimal=2)
+
+def test_calculate_errors_scores_single_row():
+    single_row = pd.DataFrame({
+        'nrmse_test': [0.1],
+        'nrmse_train': [0.15],
+        'decomp.rssd': [0.2],
+        'mape': [0.05]
+    })
+    result = ParetoUtils.calculate_errors_scores(single_row)
+    expected = np.array(0.0763763)
+    np.testing.assert_almost_equal(result, expected, decimal=7)
+
+def test_min_max_norm():
+    series = pd.Series([1, 2, 3, 4, 5])
+    normalized = ParetoUtils._min_max_norm(series)
+    expected = pd.Series([0.0, 0.25, 0.5, 0.75, 1.0])
+    pd.testing.assert_series_equal(normalized, expected)
+
+def test_min_max_norm_constant_values():
+    series = pd.Series([5, 5, 5])
+    normalized = ParetoUtils._min_max_norm(series)
+    expected = pd.Series([5, 5, 5])  # Should return the same values since they are constant
+    pd.testing.assert_series_equal(normalized, expected)
+
+def test_min_max_norm_single_value():
+    series = pd.Series([10])
+    normalized = ParetoUtils._min_max_norm(series)
+    expected = pd.Series([10])  # Should return the same value since there's only one
+    pd.testing.assert_series_equal(normalized, expected)


### PR DESCRIPTION
## Project Robyn
##Pareto Optimizer Feature without the data optimizer
Updated data mapper to map outputmodel from R to python
Calculates pareto front
This PR adds the logic that rewrite response.R based on the call from Pareto_optimizer
It also Calculates the hill hyperparameters from the response results.

## How Has This Been Tested?
Tested using test data from the `robyn_python_notebook.ipynb` before it calls robyn_output api endpoint.
Generated this new notebook to test the python logic
![image](https://github.com/user-attachments/assets/2522dadc-eb1f-4a17-b469-c2aa006b5b38)
