### PR TITLE
Test/unit tests for response curve

### DIFF
--- a/python/spec/src/robyn/modeling/pareto/response_curve.md
+++ b/python/spec/src/robyn/modeling/pareto/response_curve.md
@@ -1,0 +1,177 @@
+# CLASS
+## MetricDateInfo
+* A data class used to store information about metric locations and updated date ranges.
+* This class is part of a module related to metrics handling.
+
+# CONSTRUCTORS
+## MetricDateInfo `(metric_loc: pd.Series, date_range_updated: pd.Series)`
+* `metric_loc`: A pandas Series that contains the location of metrics.
+* `date_range_updated`: A pandas Series that contains the updated date range for the metrics.
+### USAGE
+* Use this constructor to create an instance of `MetricDateInfo` with the specified metric location and date range.
+### IMPL
+* Initializes the data class with two main attributes: `metric_loc` and `date_range_updated`.
+
+---
+
+# CLASS
+## MetricValueInfo
+* A data class used to store updated metric values and all updated values.
+* This class is part of a module related to metrics handling.
+
+# CONSTRUCTORS
+## MetricValueInfo `(metric_value_updated: np.ndarray, all_values_updated: pd.Series)`
+* `metric_value_updated`: A numpy array that contains updated metric values.
+* `all_values_updated`: A pandas Series that contains all updated values.
+### USAGE
+* Use this constructor to create an instance of `MetricValueInfo` with the specified updated metric values.
+### IMPL
+* Initializes the data class with two main attributes: `metric_value_updated` and `all_values_updated`.
+
+---
+
+# CLASS
+## ResponseOutput
+* A data class that encapsulates the results of a response calculation, including metric names, dates, inputs, responses, and a plot.
+* This class is part of a module related to response handling.
+
+# CONSTRUCTORS
+## ResponseOutput `(metric_name: str, date: pd.Series, input_total: np.ndarray, input_carryover: np.ndarray, input_immediate: np.ndarray, response_total: np.ndarray, response_carryover: np.ndarray, response_immediate: np.ndarray, usecase: str, plot: plt.Figure)`
+* `metric_name`: A string representing the name of the metric.
+* `date`: A pandas Series representing the date range.
+* `input_total`: A numpy array representing the total input values.
+* `input_carryover`: A numpy array representing the carryover input values.
+* `input_immediate`: A numpy array representing the immediate input values.
+* `response_total`: A numpy array representing the total response values.
+* `response_carryover`: A numpy array representing the carryover response values.
+* `response_immediate`: A numpy array representing the immediate response values.
+* `usecase`: A string representing the use case.
+* `plot`: A matplotlib Figure object representing the plot of the response.
+### USAGE
+* Use this constructor to create an instance of `ResponseOutput` with the specified attributes related to metric response.
+### IMPL
+* Initializes the data class with attributes to store details of the response calculation.
+
+---
+
+# CLASS
+## UseCase
+* This class is an ENUM.
+* Represents different types of use cases for response calculation.
+* Enum fields:
+  - `ALL_HISTORICAL_VEC`: Represents all historical vectors.
+  - `SELECTED_HISTORICAL_VEC`: Represents selected historical vectors.
+  - `TOTAL_METRIC_DEFAULT_RANGE`: Represents total metric with default range.
+  - `TOTAL_METRIC_SELECTED_RANGE`: Represents total metric with selected range.
+  - `UNIT_METRIC_DEFAULT_LAST_N`: Represents unit metric with default last N.
+  - `UNIT_METRIC_SELECTED_DATES`: Represents unit metric with selected dates.
+
+---
+
+# CLASS
+## ResponseCurveCalculator
+* This class is responsible for calculating response curves based on media mix modeling (MMM) data, model outputs, and hyperparameters.
+* Part of a larger module that handles data transformations and response calculations.
+
+# CONSTRUCTORS
+## ResponseCurveCalculator `(mmm_data: MMMData, model_outputs: ModelOutputs, hyperparameter: Hyperparameters)`
+* `mmm_data`: An instance of `MMMData` containing media mix modeling data.
+* `model_outputs`: An instance of `ModelOutputs` containing model output data.
+* `hyperparameter`: An instance of `Hyperparameters` containing model hyperparameters.
+### USAGE
+* Use this constructor to create an instance of `ResponseCurveCalculator` with the necessary data and hyperparameters to compute response curves.
+### IMPL
+* Initializes the class with instances of `MMMData`, `ModelOutputs`, and `Hyperparameters`.
+* Initializes a transformation object based on the provided `MMMData`.
+
+# METHODS
+## `calculate_response(select_model: str, metric_name: str, metric_value: Optional[Union[float, list[float]]] = None, date_range: Optional[str] = None, quiet: bool = False, dt_hyppar: pd.DataFrame = pd.DataFrame(), dt_coef: pd.DataFrame = pd.DataFrame()) -> ResponseOutput`
+### USAGE
+* `select_model`: A string specifying which model to use for the calculation.
+* `metric_name`: A string specifying the name of the metric to analyze.
+* `metric_value`: Optional argument specifying a float or list of floats for metric values.
+* `date_range`: Optional string specifying the date range to consider.
+* `quiet`: Boolean flag to suppress output.
+* `dt_hyppar`: A pandas DataFrame containing hyperparameter values.
+* `dt_coef`: A pandas DataFrame containing coefficient values.
+* Returns an instance of `ResponseOutput`.
+### IMPL
+* Determines the use case based on provided metric value and date range.
+* Checks the type of metric (spend, exposure, organic) using `_check_metric_type`.
+* Processes date ranges and metric values using helper functions `_check_metric_dates` and `_check_metric_value`.
+* Transforms exposure to spend if necessary using `_transform_exposure_to_spend`.
+* Applies adstock transformation using `_get_channel_hyperparams` and `transform_adstock`.
+* Applies saturation transformation using `_get_saturation_params` and `saturation_hill`.
+* Calculates final response values using model coefficients.
+* Returns a `ResponseOutput` with calculated response data.
+
+## `_which_usecase(metric_value: Optional[Union[float, list[float]]], date_range: Optional[str]) -> UseCase`
+### USAGE
+* Determines the specific use case based on metric value and date range.
+* Returns an appropriate `UseCase` enum member.
+### IMPL
+* Uses conditional logic to determine the use case based on the presence and type of `metric_value` and `date_range`.
+
+## `_check_metric_type(metric_name: str) -> Literal["spend", "exposure", "organic"]`
+### USAGE
+* Determines the type of metric based on its name.
+* Returns one of the literals: "spend", "exposure", or "organic".
+### IMPL
+* Checks the metric name against predefined lists in `MMMData` to identify its type.
+* Raises a `ValueError` if the metric type is unknown.
+
+## `_check_metric_dates(date_range: Optional[str], all_dates: pd.Series, quiet: bool) -> MetricDateInfo`
+### USAGE
+* Processes the given date range and returns the corresponding metric location and updated date range.
+* Returns an instance of `MetricDateInfo`.
+### IMPL
+* Uses conditional logic to handle different date range formats.
+* Updates the date range based on the provided or default rolling window values.
+* Prints the updated date range if `quiet` is False.
+
+## `_check_metric_value(metric_value: Optional[Union[float, list[float]]], metric_name: str, all_values: pd.Series, metric_loc: Union[slice, pd.Series]) -> MetricValueInfo`
+### USAGE
+* Processes the given metric value and returns updated metric values.
+* Returns an instance of `MetricValueInfo`.
+### IMPL
+* Updates metric values based on the provided input or uses default values.
+* Raises a `ValueError` if the length of `metric_value` does not match the selected date range.
+
+## `_transform_exposure_to_spend(metric_name: str, metric_value_updated: np.ndarray, all_values_updated: pd.Series, metric_loc: Union[slice, pd.Series]) -> pd.Series`
+### USAGE
+* Transforms exposure values to spend values based on predefined models.
+* Returns a pandas Series of updated values.
+### IMPL
+* Determines the appropriate model (non-linear or linear) based on R-squared values.
+* Calculates and updates spend values using model parameters.
+
+## `_get_spend_name(metric_name: str) -> str`
+### USAGE
+* Retrieves the spend name associated with a given metric name.
+* Returns the corresponding spend name as a string.
+### IMPL
+* Uses the index of the metric name in `paid_media_vars` to find the corresponding spend name.
+
+## `_get_channel_hyperparams(select_model: str, hpm_name: str, dt_hyppar: pd.DataFrame) -> ChannelHyperparameters`
+### USAGE
+* Retrieves hyperparameters for the specified channel and model.
+* Returns an instance of `ChannelHyperparameters`.
+### IMPL
+* Extracts hyperparameter values from `dt_hyppar` based on the selected model and adstock type.
+
+## `_get_saturation_params(select_model: str, hpm_name: str, dt_hyppar: pd.DataFrame) -> ChannelHyperparameters`
+### USAGE
+* Retrieves saturation parameters for the specified channel and model.
+* Returns an instance of `ChannelHyperparameters`.
+### IMPL
+* Extracts saturation parameter values from `dt_hyppar` based on the selected model.
+
+## `_create_response_plot(m_adstockedRW: np.ndarray, m_response: np.ndarray, input_total: np.ndarray, response_total: np.ndarray, input_carryover: np.ndarray, response_carryover: np.ndarray, input_immediate: np.ndarray, response_immediate: np.ndarray, metric_name: str, metric_type: Literal["spend", "exposure", "organic"], date_range_updated: pd.Series) -> plt.Figure`
+### USAGE
+* Creates a plot visualizing the response curve based on inputs and responses.
+* Returns a matplotlib Figure object.
+### IMPL
+* Plots the response curve and scatter plots for total, carryover, and immediate responses.
+* Configures plot labels, titles, and legends based on metric type and data.
+* Optionally includes a detailed subtitle if the input total is unique.
+* Adds a text description of the response period at the bottom of the plot.

--- a/python/spec/tests/modeling/pareto/test_response_curve.md
+++ b/python/spec/tests/modeling/pareto/test_response_curve.md
@@ -1,0 +1,15 @@
+# CLASS
+## ResponseCurveCalculator
+- This class is responsible for calculating response curves based on media mix modeling (MMM) data, model outputs, and hyperparameters.
+- Part of a larger module that handles data transformations and response calculations.
+
+# CONSTRUCTORS
+## ResponseCurveCalculator `(mmm_data: MMMData, model_outputs: ModelOutputs, hyperparameter: Hyperparameters)`
+### USAGE
+- Use this constructor to create an instance of `ResponseCurveCalculator` with the necessary data and hyperparameters to compute response curves.
+
+### IMPL
+- The constructor should be tested by initializing the `ResponseCurveCalculator` class with mock instances of `MMMData`, `ModelOutputs`, and `Hyperparameters`.
+- Verify that the instance variables `mmm_data`, `model_outputs`, and `hyperparameter` are correctly assigned.
+- Ensure that `self.transformation` is initialized as an instance of the `Transformation` class with the `mmm_data` passed correctly.
+- Test the constructor with edge cases like passing `None` or incorrect types to ensure proper error handling.

--- a/python/src/robyn/modeling/pareto/response_curve.py
+++ b/python/src/robyn/modeling/pareto/response_curve.py
@@ -239,7 +239,7 @@ class ResponseCurveCalculator:
             date_range_updated = all_dates[metric_loc]
         elif date_range.startswith("last_"):
             n_periods = int(date_range.split("_")[1])
-            metric_loc = slice(end_rw - n_periods + 1, end_rw)
+            metric_loc = slice(end_rw - n_periods, end_rw)
             date_range_updated = all_dates[metric_loc]
         elif isinstance(date_range, list) and len(date_range) == 2:
             start_date, end_date = pd.to_datetime(date_range)

--- a/python/src/robyn/modeling/pareto/response_curve.py
+++ b/python/src/robyn/modeling/pareto/response_curve.py
@@ -239,7 +239,7 @@ class ResponseCurveCalculator:
             date_range_updated = all_dates[metric_loc]
         elif date_range.startswith("last_"):
             n_periods = int(date_range.split("_")[1])
-            metric_loc = slice(end_rw - n_periods, end_rw)
+            metric_loc = slice(end_rw - n_periods, end_rw + 1)
             date_range_updated = all_dates[metric_loc]
         elif isinstance(date_range, list) and len(date_range) == 2:
             start_date, end_date = pd.to_datetime(date_range)

--- a/python/src/robyn/modeling/pareto/response_curve.py
+++ b/python/src/robyn/modeling/pareto/response_curve.py
@@ -233,13 +233,12 @@ class ResponseCurveCalculator:
     ) -> MetricDateInfo:
         start_rw = self.mmm_data.mmmdata_spec.rolling_window_start_which
         end_rw = self.mmm_data.mmmdata_spec.rolling_window_end_which
-
         if date_range == "all" or date_range is None:
             metric_loc = slice(start_rw, end_rw)
             date_range_updated = all_dates[metric_loc]
-        elif date_range.startswith("last_"):
+        elif isinstance(date_range, str) and date_range.startswith("last_"):
             n_periods = int(date_range.split("_")[1])
-            metric_loc = slice(end_rw - n_periods, end_rw + 1)
+            metric_loc = slice(end_rw - n_periods, end_rw)
             date_range_updated = all_dates[metric_loc]
         elif isinstance(date_range, list) and len(date_range) == 2:
             start_date, end_date = pd.to_datetime(date_range)

--- a/python/tests/modeling/pareto/test_response_curve.py
+++ b/python/tests/modeling/pareto/test_response_curve.py
@@ -1,0 +1,244 @@
+import unittest
+from unittest.mock import MagicMock
+import pandas as pd
+import numpy as np
+from matplotlib.figure import Figure
+from robyn.data.entities.mmmdata import MMMData
+from robyn.modeling.entities.modeloutputs import ModelOutputs
+from robyn.data.entities.hyperparameters import ChannelHyperparameters, Hyperparameters
+from robyn.data.entities.enums import AdstockType
+from robyn.modeling.transformations.transformations import Transformation
+from robyn.modeling.pareto.response_curve import (
+    ResponseCurveCalculator,
+    ResponseOutput,
+    UseCase,
+    MetricDateInfo,
+    MetricValueInfo,
+)
+
+
+class TestResponseCurveCalculator(unittest.TestCase):
+
+    def setUp(self):
+        # Mocking the dependencies
+        self.mock_mmm_data = MagicMock(spec=MMMData)
+        self.mock_mmm_data.mmmdata_spec = MagicMock()
+        self.mock_model_outputs = MagicMock(spec=ModelOutputs)
+        self.mock_hyperparameter = MagicMock(spec=Hyperparameters)
+        self.mock_transformation = MagicMock(spec=Transformation)
+
+        # Instantiating the ResponseCurveCalculator
+        self.calculator = ResponseCurveCalculator(
+            self.mock_mmm_data, self.mock_model_outputs, self.mock_hyperparameter
+        )
+
+    def test_calculate_response(self):
+        # Mock data setup
+        self.mock_mmm_data.data = pd.DataFrame({
+            "spend_metric": [1, 2, 3, 4, 5],
+            "date_var": pd.date_range("2020-01-01", periods=5),
+        })
+        self.mock_mmm_data.mmmdata_spec.date_var = "date_var"
+        self.mock_mmm_data.mmmdata_spec.paid_media_spends = ["spend_metric"]
+        self.mock_mmm_data.mmmdata_spec.paid_media_vars = ["exposure_metric"]
+        self.mock_mmm_data.mmmdata_spec.organic_vars = ["organic_metric"]
+        self.mock_mmm_data.mmmdata_spec.rolling_window_start_which = 0 
+        self.mock_mmm_data.mmmdata_spec.rolling_window_end_which = 5 
+        select_model = "model1"
+        metric_name = "spend_metric"
+        metric_value = [100, 200, 300, 400, 500]
+        date_range = "all"
+        dt_hyppar = pd.DataFrame({
+            "solID": ["model1"],
+            "spend_metric_alphas": [0.1],
+            "spend_metric_gammas": [0.2]
+        })
+        dt_coef = pd.DataFrame({
+            "solID": ["model1"],
+            "rn": ["spend_metric"],
+            "coef": [0.5]
+        })
+        # Mock the transformation methods
+        self.calculator.transformation = MagicMock()  # Ensure transformation is a mock
+        self.calculator.transformation.transform_adstock.return_value = MagicMock(
+            x_decayed=np.array([1, 2, 3]),
+            x_imme=np.array([0.5, 1, 1.5]),
+            x=np.array([1, 2, 3]),
+        )
+
+        response_output = self.calculator.calculate_response(
+            select_model,
+            metric_name,
+            metric_value,
+            date_range,
+            False,
+            dt_hyppar,
+            dt_coef=dt_coef,
+        )
+
+        self.assertIsInstance(response_output, ResponseOutput)
+        self.assertEqual(response_output.metric_name, metric_name)
+
+    def test__which_usecase(self):
+        usecase = self.calculator._which_usecase(None, None)
+        self.assertEqual(usecase, UseCase.ALL_HISTORICAL_VEC)
+
+        usecase = self.calculator._which_usecase(None, "selected")
+        self.assertEqual(usecase, UseCase.SELECTED_HISTORICAL_VEC)
+
+        usecase = self.calculator._which_usecase(10.0, None)
+        self.assertEqual(usecase, UseCase.TOTAL_METRIC_DEFAULT_RANGE)
+
+        usecase = self.calculator._which_usecase(10.0, "selected")
+        self.assertEqual(usecase, UseCase.TOTAL_METRIC_SELECTED_RANGE)
+
+        usecase = self.calculator._which_usecase([1.0, 2.0, 3.0], None)
+        self.assertEqual(usecase, UseCase.UNIT_METRIC_DEFAULT_LAST_N)
+
+        usecase = self.calculator._which_usecase([1.0, 2.0, 3.0], "selected")
+        self.assertEqual(usecase, UseCase.UNIT_METRIC_SELECTED_DATES)
+
+    def test__check_metric_type(self):
+        self.mock_mmm_data.mmmdata_spec.paid_media_spends = ["spend_metric"]
+        self.mock_mmm_data.mmmdata_spec.paid_media_vars = ["exposure_metric"]
+        self.mock_mmm_data.mmmdata_spec.organic_vars = ["organic_metric"]
+
+        metric_type = self.calculator._check_metric_type("spend_metric")
+        self.assertEqual(metric_type, "spend")
+
+        metric_type = self.calculator._check_metric_type("exposure_metric")
+        self.assertEqual(metric_type, "exposure")
+
+        metric_type = self.calculator._check_metric_type("organic_metric")
+        self.assertEqual(metric_type, "organic")
+
+        with self.assertRaises(ValueError):
+            self.calculator._check_metric_type("unknown_metric")
+
+    def test__check_metric_dates(self):
+        all_dates = pd.Series(pd.date_range("2020-01-01", periods=5))
+        self.mock_mmm_data.mmmdata_spec.rolling_window_start_which = 0
+        self.mock_mmm_data.mmmdata_spec.rolling_window_end_which = 5
+
+        metric_date_info = self.calculator._check_metric_dates(None, all_dates, False)
+        self.assertIsInstance(metric_date_info, MetricDateInfo)
+        self.assertEqual(len(metric_date_info.date_range_updated), 5)
+
+        metric_date_info = self.calculator._check_metric_dates(
+            "last_3", all_dates, False
+        )
+        self.assertEqual(len(metric_date_info.date_range_updated), 3)
+
+        with self.assertRaises(ValueError):
+            self.calculator._check_metric_dates("invalid_range", all_dates, False)
+
+    def test__check_metric_value(self):
+        all_values = pd.Series([1, 2, 3, 4, 5])
+        metric_loc = slice(0, 3)
+
+        metric_value_info = self.calculator._check_metric_value(
+            None, "metric_name", all_values, metric_loc
+        )
+        self.assertIsInstance(metric_value_info, MetricValueInfo)
+        self.assertTrue((metric_value_info.metric_value_updated == [1, 2, 3]).all())
+
+        metric_value_info = self.calculator._check_metric_value(
+            10, "metric_name", all_values, metric_loc
+        )
+        self.assertTrue((metric_value_info.metric_value_updated == [10, 10, 10]).all())
+
+        with self.assertRaises(ValueError):
+            self.calculator._check_metric_value(
+                [1, 2], "metric_name", all_values, metric_loc
+            )
+
+    def test__transform_exposure_to_spend(self):
+        metric_name = "exposure_metric"
+        metric_value_updated = np.array([100, 200, 300])
+        all_values_updated = pd.Series([1, 2, 3, 4, 5])
+        metric_loc = slice(0, 3)
+
+        self.mock_mmm_data.mmmdata_spec.modNLS = {
+            "results": pd.DataFrame(
+                {
+                    "channel": ["exposure_metric"],
+                    "rsq_nls": [0.9],
+                    "rsq_lm": [0.8],
+                    "Vmax": [1000],
+                    "Km": [10],
+                    "coef_lm": [1],
+                }
+            )
+        }
+
+        updated_values = self.calculator._transform_exposure_to_spend(
+            metric_name, metric_value_updated, all_values_updated, metric_loc
+        )
+        self.assertIsInstance(updated_values, pd.Series)
+
+    def test__get_spend_name(self):
+        self.mock_mmm_data.mmmdata_spec.paid_media_spends = ["spend_metric"]
+        self.mock_mmm_data.mmmdata_spec.paid_media_vars = ["exposure_metric"]
+
+        spend_name = self.calculator._get_spend_name("exposure_metric")
+        self.assertEqual(spend_name, "spend_metric")
+
+    def test__get_channel_hyperparams(self):
+        dt_hyppar = pd.DataFrame(
+            {
+                "solID": ["model1"],
+                "spend_metric_thetas": [[0.1]],
+                "spend_metric_shapes": [[0.2]],
+                "spend_metric_scales": [[0.3]],
+            }
+        )
+
+        self.mock_hyperparameter.adstock = AdstockType.WEIBULL
+
+        channel_hyperparams = self.calculator._get_channel_hyperparams(
+            "model1", "spend_metric", dt_hyppar
+        )
+        self.assertIsInstance(channel_hyperparams, ChannelHyperparameters)
+
+    def test__get_saturation_params(self):
+        dt_hyppar = pd.DataFrame(
+            {
+                "solID": ["model1"],
+                "spend_metric_alphas": [[0.1]],
+                "spend_metric_gammas": [[0.2]],
+            }
+        )
+
+        saturation_params = self.calculator._get_saturation_params(
+            "model1", "spend_metric", dt_hyppar
+        )
+        self.assertIsInstance(saturation_params, ChannelHyperparameters)
+
+    def test__create_response_plot(self):
+        m_adstockedRW = np.array([1, 2, 3, 4, 5])
+        m_response = np.array([1, 2, 3, 4, 5])
+        input_total = np.array([1, 2, 3, 4, 5])
+        response_total = np.array([1, 2, 3, 4, 5])
+        input_carryover = np.array([1, 2, 3, 4, 5])
+        response_carryover = np.array([1, 2, 3, 4, 5])
+        input_immediate = np.array([1, 2, 3, 4, 5])
+        response_immediate = np.array([1, 2, 3, 4, 5])
+        metric_name = "metric_name"
+        metric_type = "spend"
+        date_range_updated = pd.Series(pd.date_range("2020-01-01", periods=5))
+
+        plot = self.calculator._create_response_plot(
+            m_adstockedRW,
+            m_response,
+            input_total,
+            response_total,
+            input_carryover,
+            response_carryover,
+            input_immediate,
+            response_immediate,
+            metric_name,
+            metric_type,
+            date_range_updated,
+        )
+
+        self.assertIsInstance(plot, Figure)

--- a/python/tests/modeling/pareto/test_response_curve.py
+++ b/python/tests/modeling/pareto/test_response_curve.py
@@ -116,6 +116,7 @@ class TestResponseCurveCalculator(unittest.TestCase):
             self.calculator._check_metric_type("unknown_metric")
 
     def test__check_metric_dates(self):
+
         all_dates = pd.Series(pd.date_range("2020-01-01", periods=5))
         self.mock_mmm_data.mmmdata_spec.rolling_window_start_which = 0
         self.mock_mmm_data.mmmdata_spec.rolling_window_end_which = 5
@@ -128,6 +129,11 @@ class TestResponseCurveCalculator(unittest.TestCase):
             "last_3", all_dates, False
         )
         self.assertEqual(len(metric_date_info.date_range_updated), 3)
+
+        metric_date_info = self.calculator._check_metric_dates(
+            ["2020-01-01", "2020-01-04"], all_dates, False
+        )
+        self.assertEqual(len(metric_date_info.date_range_updated), 4)
 
         with self.assertRaises(ValueError):
             self.calculator._check_metric_dates("invalid_range", all_dates, False)


### PR DESCRIPTION
## Project Robyn

Add Unit Tests for `response_curve` pareto method

Fixes # (issue)

Fix this line: 
`metric_loc = slice(end_rw - n_periods + 1, end_rw)`
to
`metric_loc = slice(end_rw - n_periods, end_rw + 1)`

eg, date range is:

`[1,2,3,4,5]`

`rolling_window_start_which = 1`
`rolling_window_end_which = 5`

`slice(1,5)` would return `[1,2,3,4]` and not `[1,2,3,4,5]`


## Test Plan Results
<img width="1421" alt="image" src="https://github.com/user-attachments/assets/d2106071-b630-424a-bcfe-04438e984312">


<img width="834" alt="image" src="https://github.com/user-attachments/assets/f064527b-20f3-449a-b8c5-5301f517b510">


