### PR TITLE
fix: adstock plot warning on changing geom_text() to annotate()

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Robyn
 Type: Package
 Title: Semi-Automated Marketing Mix Modeling (MMM) from Meta Marketing Science 
-Version: 3.12.0.9000
+Version: 3.12.0.9001
 Authors@R: c(
     person("Gufeng", "Zhou", , "gufeng@meta.com", c("cre", "aut")),
     person("Igor", "Skokan", , "igorskokan@meta.com", c("aut")),

--- a/R/R/plots.R
+++ b/R/R/plots.R
@@ -473,7 +473,7 @@ robyn_onepagers <- function(
           geom_line(aes(color = .data$channel)) +
           facet_wrap(~ .data$channel) +
           geom_hline(yintercept = 0.5, linetype = "dashed", color = "gray") +
-          geom_text(aes(x = max(.data$x), y = 0.5, vjust = -0.5, hjust = 1, label = "Halflife"), colour = "gray") +
+          annotate("text", x = max(weibullCollect$x), y = 0.5, vjust = -0.5, hjust = 1, label = "Halflife", colour = "gray") +
           theme_lares(background = "white", legend = "none", grid = "Xx") +
           labs(
             title = paste("Weibull", wb_type, "Adstock: Flexible Rate Over Time"),

--- a/R/R/transformation.R
+++ b/R/R/transformation.R
@@ -249,7 +249,7 @@ plot_adstock <- function(plot = TRUE) {
     p1 <- ggplot(geomCollect, aes(x = .data$x, y = .data$decay_accumulated)) +
       geom_line(aes(color = .data$theta_halflife)) +
       geom_hline(yintercept = 0.5, linetype = "dashed", color = "gray") +
-      geom_text(aes(x = max(.data$x), y = 0.5, vjust = -0.5, hjust = 1, label = "Halflife"), colour = "gray") +
+      annotate("text", x = max(geomCollect$x), y = 0.5, vjust = -0.5, hjust = 1, label = "Halflife", colour = "gray") +
       labs(
         title = "Geometric Adstock\n(Fixed decay rate)",
         subtitle = "Halflife = time until effect reduces to 50%",
@@ -290,9 +290,7 @@ plot_adstock <- function(plot = TRUE) {
       geom_line(aes(color = .data$scale)) +
       facet_grid(.data$shape ~ .data$type) +
       geom_hline(yintercept = 0.5, linetype = "dashed", color = "gray") +
-      geom_text(aes(x = max(.data$x), y = 0.5, vjust = -0.5, hjust = 1, label = "Halflife"),
-        colour = "gray"
-      ) +
+      annotate("text", x = max(weibullCollect$x), y = 0.5, vjust = -0.5, hjust = 1, label = "Halflife", colour = "gray") +
       labs(
         title = "Weibull Adstock CDF vs PDF\n(Flexible decay rate)",
         subtitle = "Halflife = time until effect reduces to 50%",

--- a/R/man/Robyn.Rd
+++ b/R/man/Robyn.Rd
@@ -2,8 +2,8 @@
 % Please edit documentation in R/imports.R
 \docType{package}
 \name{Robyn}
-\alias{Robyn}
 \alias{Robyn-package}
+\alias{Robyn}
 \title{Robyn MMM Project from Meta Marketing Science}
 \description{
 Robyn is an automated Marketing Mix Modeling (MMM) code. It aims to reduce human


### PR DESCRIPTION
Fixing the following warning everytime a one-pager is created:

```
Warning in geom_text(aes(x = max(.data$x), y = 0.5, vjust = -0.5, hjust = 1, :
All aesthetics have length 1, but the data has 250 rows.
ℹ Please consider using annotate() or provide this layer with data containing a single row.
```

The warning message is due to the fact that geom_text is trying to apply the same label ("Halflife") across multiple rows of the data, which causes a mismatch in the number of aesthetics. 