### PR TITLE
Remove duplicate nevergrad dependency

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "plotnine",
     "nevergrad",
     "PyQt6",
-    "nevergrad",
     "seaborn",
     "tqdm",
     "rpy2",

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -14,5 +14,4 @@ rpy2==3.5.16
 plotly==5.24.1
 pytest==8.3.3
 nlopt==2.8.0
-nevergrad==1.0.5
 ipykernel==6.29.5


### PR DESCRIPTION
## Project Robyn

Looking at the `pyproject.toml` and `requirements.txt` files, `nevergrad` is listed twice as a dependency. This PR removes the duplicate dependency from both files. This should only be a cosmetic change.

## Type of change
- remove duplicate nevergrad from requirements.txt for robynpy
- remove duplicate nevergrad from pyproject.toml for robynpy
