### PR TITLE
Optimize _geometric_adstock for 99% function speedup, reducing total model train time by ~40% - Python version

### DIFF
--- a/python/src/robyn/modeling/ridge/ridge_data_builder.py
+++ b/python/src/robyn/modeling/ridge/ridge_data_builder.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Dict, Optional, Tuple
 import pandas as pd
 import numpy as np
+from scipy.signal import lfilter
 
 
 class RidgeDataBuilder:
@@ -166,12 +167,11 @@ class RidgeDataBuilder:
         return hyper_collect
 
     def _geometric_adstock(self, x: pd.Series, theta: float) -> pd.Series:
-        # print(f"Before adstock: {x.head()}")
-        y = x.copy()
-        for i in range(1, len(x)):
-            y.iloc[i] += theta * y.iloc[i - 1]
-        # print(f"After adstock: {y.head()}")
-        return y
+
+        x_array = x.values
+        # Use lfilter to efficiently compute the geometric transformation
+        y = lfilter([1], [1, -theta], x_array)
+        return pd.Series(y, index=x.index)
 
     def _hill_transformation(
         self, x: pd.Series, alpha: float, gamma: float

--- a/python/tests/unit/modeling/ridge/test_adstock.py
+++ b/python/tests/unit/modeling/ridge/test_adstock.py
@@ -1,0 +1,31 @@
+import pytest
+import numpy as np
+import pandas as pd
+from scipy.signal import lfilter
+from robyn.modeling.ridge.ridge_data_builder import RidgeDataBuilder
+
+
+def original_geometric_adstock(x: pd.Series, theta: float) -> pd.Series:
+    y = x.copy()
+    for i in range(1, len(x)):
+        y.iloc[i] += theta * y.iloc[i - 1]
+    return y
+
+
+@pytest.mark.parametrize("theta", [0, 0.5, 0.8, 1])
+def test_geometric_adstock(theta):
+    x = pd.Series(np.random.rand(10_000))  # Random test data
+
+    # Instantiate the RidgeDataBuilder object (without requiring real data)
+    dummy_data = None
+    ridge_builder = RidgeDataBuilder(dummy_data, dummy_data)
+
+    # Call the actual function from the RidgeDataBuilder instance
+    optimized = ridge_builder._geometric_adstock(x, theta)
+
+    # Compute the expected output using the original function
+    original = original_geometric_adstock(x, theta)
+
+    assert np.allclose(
+        original, optimized, atol=1e-6
+    ), f"Mismatch found for theta={theta}"


### PR DESCRIPTION
## Project Robyn

### Summary  
This PR optimizes `_geometric_adstock`, the main performance bottleneck, reducing its execution time by **~99%** and improving the **total model train time by ~40%** on Python version.

### Fixes  
This PR does not address an existing GitHub issue but significantly improves performance.

### Type of change  
- **fix**: Performance optimization (non-breaking change that improves efficiency)
- **test**: Added unit test to validate correctness  

### Motivation & Context  
- `_geometric_adstock` previously accounted for **39% of the total model train time**, significantly slowing down model execution.  
- This function was rewritten using `scipy.signal.lfilter`, replacing a Python loop with a **highly efficient SciPy-based implementation (built on NumPy)**.  
- This change **improves execution time from 108.9s → 0.495s** (~99% speedup), leading to an **overall app model train time reduction of ~40%**.  

### **Performance Benchmark** (tutorial1.ipynb, Trial=1, iterations=2000)
**Before Optimization:**  
- `_geometric_adstock`: **108.9s** (39% of total model train time)  
- **Total model train time:** **277.9s**  

**After Optimization:**  
- `_geometric_adstock`: **0.495s** (**99% faster**)  
- **Total model train time:** **166.7s** (**40% faster**)  