### PR TITLE
Fix `hyperparameters.png` with small intervals

### DIFF
--- a/R/R/plots.R
+++ b/R/R/plots.R
@@ -78,15 +78,16 @@ robyn_plots <- function(
         ungroup() %>%
         mutate(
           type = factor(.data$type, levels = unique(.data$type)),
-          channel = factor(.data$channel, levels = rev(unique(.data$channel)))
+          channel = factor(.data$channel, levels = unique(.data$channel))
         )
       all_plots[["pSamp"]] <- ggplot(resultHypParam.melted) +
-        facet_grid(. ~ .data$type, scales = "free") +
+        facet_grid(.data$channel ~ .data$type, scales = "free") +
         geom_violin(
           aes(x = .data$value, y = .data$channel, color = .data$channel, fill = .data$channel),
           alpha = .8, size = 0
         ) +
         theme_lares(background = "white", legend = "none", pal = 1) +
+        theme(strip.text.y.right = element_blank()) +
         labs(
           title = "Hyperparameters Optimization Distributions",
           subtitle = paste0(


### PR DESCRIPTION
## Project Robyn

When I set small intervals on hyperparameters, the resulting `hyperparameters.png` plot does not show the density correctly.

I have a model with the following hyperparameters:

```r
hyperparameters <- list(
  ...
  media_alphas = c(8, 9),
  media_gammas = c(0.001, 0.3),
  media_scales = c(0.0001, 0.001),  # <- Very narrow interval
  media_shapes = c(0.0001, 0.001),  # <- Very narrow interval
  ...
)
```
While the model fits correctly and does not show any issues, the resulting `hyperparameters.png` plot does not show any density for scale and shape for **all** parameters.

![hypersampling](https://github.com/user-attachments/assets/c46e8cea-a2dc-46e8-b7fa-61fa5eccdce9)

This PR updates the code so that

1) the density is correctly shown for all parameters,
2) the ordering is identical to previous versions, and
3) there is no additional label on the right side of the plot (which is added after `face_grid` change)

The resulting chart looks like this:

![hypersampling](https://github.com/user-attachments/assets/060f7020-2263-4bd0-a00a-56541bc79b48)

## Type of change
- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: API change with a documentation update
- [ ] test: Additional test coverage
- [ ] reformat: Code cleanup, recoding or reformating code

## How Has This Been Tested?
- [x] Fork the repo and create your branch from master (latest dev version).
- [ ] If you've changed docuemntation, run `devtools::document()`. Should update .Rd files.
- [x] Ensure all tests pass, run `devtools::check()`. Should have no notes, no warning, no errors.
- [x] Make sure your code lints.
